### PR TITLE
fix: correct heredoc terminator indentation in backend workflow

### DIFF
--- a/.github/workflows/update-github-repositories-details.yml
+++ b/.github/workflows/update-github-repositories-details.yml
@@ -173,7 +173,7 @@ jobs:
             walk(generatedDir);
             const records = files.sort().map((filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8')));
             fs.writeFileSync(baselinePath, `${JSON.stringify(records, null, 2)}\n`);
-            NODE
+          NODE
             echo "Captured generated-layer baseline from '$DATA_GENERATED_DIR'."
             echo "TYPESCRIPT_BASELINE_PRESENT=true" >> "$GITHUB_ENV"
             echo "TYPESCRIPT_BASELINE_SOURCE=generated-dir" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Problem

The scheduled `1-update-github-repositories-details` workflow started failing with:

```
warning: here-document at line 5 delimited by end-of-file (wanted `NODE')
syntax error: unexpected end of file
```

Root cause: in the **Capture existing repository details baseline** step, the closing `NODE` heredoc terminator was indented at 12 spaces inside the `if` block. GitHub Actions' `run: |` YAML block strips the minimum indentation of the block (10 spaces), leaving the terminator as `  NODE` (2 leading spaces). Bash's `<<'NODE'` heredoc requires a terminator with **zero** leading spaces — so bash scanned to EOF and raised a syntax error.

## Fix

Moved the closing `NODE` on line 176 from 12-space indent to 10-space indent (matching the outer `run:` block level), so after YAML stripping it appears at column 0 as bash requires.

## References

Failing run: https://github.com/rpothin/PowerPlatform-OpenSource-Hub/actions/runs/25732110239/job/75559688541