### PR TITLE
fix: resolve PAT-policy failures and optimize performance via GraphQL batching

### DIFF
--- a/.github/workflows/update-github-repositories-details.yml
+++ b/.github/workflows/update-github-repositories-details.yml
@@ -263,6 +263,12 @@ jobs:
             if (failures > 0) {
               blockingFailures.push(`TypeScript pipeline had ${failures} repository detail hydration failure(s); all must succeed in production live mode`);
             }
+
+            const patPolicyFailures = metrics.patPolicyFailures ?? 0;
+            if (patPolicyFailures > 0) {
+              const names = (metrics.patPolicyFailureNames ?? []).join(', ');
+              console.log(`::warning::TypeScript pipeline skipped ${patPolicyFailures} repo(s) due to PAT policy restrictions (fine-grained PAT lifetime exceeded enterprise limit). Affected repos: ${names}. Consider switching to a classic PAT with public_repo scope.`);
+            }
           }
 
           if ((report.failures.invalidInputs ?? []).length > 0) {

--- a/Pipeline/src/generator.ts
+++ b/Pipeline/src/generator.ts
@@ -24,6 +24,20 @@ export interface GenerateOptions {
   continueOnRepositoryError?: boolean;
 }
 
+/** Returns true if the error is a GitHub enterprise PAT-policy rejection (HTTP 403 with lifetime restriction message). */
+function isPatPolicyError(error: unknown): boolean {
+  const messageSources = [
+    error instanceof Error ? error.message : undefined,
+    error instanceof Error ? (error.cause instanceof Error ? error.cause.message : undefined) : undefined,
+  ];
+  const octokitError = error as { response?: { data?: { message?: string } } };
+  if (octokitError?.response?.data?.message) {
+    messageSources.push(octokitError.response.data.message);
+  }
+  const combined = messageSources.filter(Boolean).join(" ").toLowerCase();
+  return combined.includes("fine-grained personal access tokens") || combined.includes("enterprise forbids access");
+}
+
 export async function generateRepositoryDetails(options: GenerateOptions): Promise<GenerateResult> {
   assertJsonPath(options.outputPath, "output");
   if (options.metricsPath !== undefined) {
@@ -75,6 +89,12 @@ export async function generateRepositoryDetails(options: GenerateOptions): Promi
       const details = await options.provider.getRepositoryDetails(repository.fullName, repository);
       return normalizeRepositoryRecord(repository, details, provenance);
     } catch (error) {
+      if (isPatPolicyError(error)) {
+        metrics.patPolicyFailures += 1;
+        metrics.patPolicyFailureNames.push(repository.fullName);
+        metrics.warnings.push(`Skipping '${repository.fullName}' due to PAT policy restriction: ${errorMessage(error)}`);
+        return null;
+      }
       metrics.detailFailures += 1;
       if (options.continueOnRepositoryError ?? true) {
         metrics.warnings.push(`Skipping '${repository.fullName}' because detail hydration failed: ${errorMessage(error)}`);

--- a/Pipeline/src/generator.ts
+++ b/Pipeline/src/generator.ts
@@ -119,6 +119,9 @@ function createMetrics(criteriaCount: number): PipelineMetrics {
     activeRepositories: 0,
     detailRequests: 0,
     detailFailures: 0,
+    patPolicyFailures: 0,
+    patPolicyFailureNames: [],
+    detailBatchCalls: 0,
     generatedRecords: 0,
     warnings: [],
     elapsedMs: 0

--- a/Pipeline/src/generator.ts
+++ b/Pipeline/src/generator.ts
@@ -83,27 +83,60 @@ export async function generateRepositoryDetails(options: GenerateOptions): Promi
     workflowRunId: options.workflowRunId ?? process.env.GITHUB_RUN_ID ?? "local"
   };
 
-  const hydratedRecords = await mapWithConcurrency(activeRepositories, options.concurrency ?? 4, async (repository) => {
-    metrics.detailRequests += 1;
-    try {
-      const details = await options.provider.getRepositoryDetails(repository.fullName, repository);
-      return normalizeRepositoryRecord(repository, details, provenance);
-    } catch (error) {
-      if (isPatPolicyError(error)) {
-        metrics.patPolicyFailures += 1;
-        metrics.patPolicyFailureNames.push(repository.fullName);
-        metrics.warnings.push(`Skipping '${repository.fullName}' due to PAT policy restriction: ${errorMessage(error)}`);
-        return null;
-      }
-      metrics.detailFailures += 1;
-      if (options.continueOnRepositoryError ?? true) {
-        metrics.warnings.push(`Skipping '${repository.fullName}' because detail hydration failed: ${errorMessage(error)}`);
-        return null;
-      }
+  let hydratedRecords: Array<RepositoryRecord | null>;
 
-      throw new Error(`Failed hydrating repository '${repository.fullName}'.`, { cause: error });
-    }
-  });
+  if (options.provider.batchGetRepositoryDetails !== undefined) {
+    const batchSize = 20;
+    metrics.detailBatchCalls = Math.ceil(activeRepositories.length / batchSize);
+    const batchResults = await options.provider.batchGetRepositoryDetails(activeRepositories);
+
+    hydratedRecords = activeRepositories.map((repository) => {
+      metrics.detailRequests += 1;
+      const result = batchResults.get(repository.fullName);
+      if (result === undefined) {
+        metrics.detailFailures += 1;
+        metrics.warnings.push(`Skipping '${repository.fullName}' because detail hydration returned no result.`);
+        return null;
+      }
+      if (result instanceof Error) {
+        if (isPatPolicyError(result)) {
+          metrics.patPolicyFailures += 1;
+          metrics.patPolicyFailureNames.push(repository.fullName);
+          metrics.warnings.push(`Skipping '${repository.fullName}' due to PAT policy restriction: ${result.message}`);
+          return null;
+        }
+        metrics.detailFailures += 1;
+        if (options.continueOnRepositoryError ?? true) {
+          metrics.warnings.push(`Skipping '${repository.fullName}' because detail hydration failed: ${result.message}`);
+          return null;
+        }
+        throw new Error(`Failed hydrating repository '${repository.fullName}'.`, { cause: result });
+      }
+      return normalizeRepositoryRecord(repository, result, provenance);
+    });
+  } else {
+    hydratedRecords = await mapWithConcurrency(activeRepositories, options.concurrency ?? 4, async (repository) => {
+      metrics.detailRequests += 1;
+      try {
+        const details = await options.provider.getRepositoryDetails(repository.fullName, repository);
+        return normalizeRepositoryRecord(repository, details, provenance);
+      } catch (error) {
+        if (isPatPolicyError(error)) {
+          metrics.patPolicyFailures += 1;
+          metrics.patPolicyFailureNames.push(repository.fullName);
+          metrics.warnings.push(`Skipping '${repository.fullName}' due to PAT policy restriction: ${errorMessage(error)}`);
+          return null;
+        }
+        metrics.detailFailures += 1;
+        if (options.continueOnRepositoryError ?? true) {
+          metrics.warnings.push(`Skipping '${repository.fullName}' because detail hydration failed: ${errorMessage(error)}`);
+          return null;
+        }
+
+        throw new Error(`Failed hydrating repository '${repository.fullName}'.`, { cause: error });
+      }
+    });
+  }
 
   const minPopularityScore = options.minPopularityScore ?? 10;
   const records = sortByPopularity(

--- a/Pipeline/src/providers.ts
+++ b/Pipeline/src/providers.ts
@@ -58,6 +58,38 @@ interface GitHubCommunityProfileResponse {
   };
 }
 
+interface GraphQLRepositoryNode {
+  forkCount: number;
+  stargazerCount: number;
+  watchers: { totalCount: number };
+  primaryLanguage: { name: string } | null;
+  isTemplate: boolean;
+  hasIssuesEnabled: boolean;
+  latestRelease: { name: string | null; tagName: string; url: string; publishedAt: string | null } | null;
+  repositoryTopics: { nodes: Array<{ topic: { name: string } }> };
+  languages: { nodes: Array<{ name: string }> };
+  codeOfConduct: { key: string; name: string; url: string } | null;
+  securityPolicyUrl: string | null;
+  fundingLinks: Array<{ platform: string; url: string }>;
+  goodFirstIssues: { totalCount: number };
+  helpWanted: { totalCount: number };
+}
+
+interface GraphQLRateLimit {
+  remaining: number;
+  resetAt: string;
+}
+
+interface GraphQLErrorResponse {
+  message: string;
+  path?: Array<string | number>;
+}
+
+interface GraphQLBatchResponse {
+  data?: Record<string, unknown>;
+  errors?: GraphQLErrorResponse[];
+}
+
 export interface GitHubClient {
   rest: {
     search: {
@@ -71,7 +103,7 @@ export interface GitHubClient {
       getLatestRelease(parameters: { owner: string; repo: string }): Promise<{ data: GitHubReleaseResponse }>;
     };
   };
-  request<T>(route: string, parameters: { owner: string; repo: string }): Promise<{ data: T }>;
+  request<T>(route: string, parameters: Record<string, unknown>): Promise<{ data: T }>;
 }
 
 export class DryRunProvider implements CandidateProvider {
@@ -200,6 +232,141 @@ export class OctokitRepositoryProvider implements CandidateProvider {
       hasGoodFirstIssues: goodFirstIssues > 0,
       openedHelpWantedIssues: helpWantedIssues,
       hasHelpWantedIssues: helpWantedIssues > 0
+    };
+  }
+
+  public async batchGetRepositoryDetails(repos: SearchRepository[]): Promise<Map<string, RepositoryDetails | Error>> {
+    const result = new Map<string, RepositoryDetails | Error>();
+    const batchSize = 20;
+
+    for (let i = 0; i < repos.length; i += batchSize) {
+      const batch = repos.slice(i, i + batchSize);
+      const query = this.buildBatchQuery(batch);
+
+      try {
+        const response = await this.client.request<GraphQLBatchResponse>("POST /graphql", { query });
+        const responseData = response.data.data ?? {};
+        const gqlErrors = response.data.errors ?? [];
+
+        if (Object.keys(responseData).length === 0 && gqlErrors.length > 0) {
+          const batchError = new Error(gqlErrors.map((error) => error.message).join("; "));
+          for (const repo of batch) {
+            result.set(repo.fullName, batchError);
+          }
+          continue;
+        }
+
+        const rateLimit = responseData["rateLimit"] as GraphQLRateLimit | undefined;
+        if (rateLimit !== undefined && rateLimit.remaining < 50) {
+          const resetAt = new Date(rateLimit.resetAt).getTime();
+          const waitMs = Math.max(0, resetAt - Date.now()) + 1000;
+          await new Promise((resolve) => setTimeout(resolve, waitMs));
+        }
+
+        const failedAliases = new Set<string>();
+        for (const gqlError of gqlErrors) {
+          const alias = typeof gqlError.path?.[0] === "string" ? gqlError.path[0] : undefined;
+          if (alias !== undefined) {
+            failedAliases.add(alias);
+          }
+        }
+
+        for (let j = 0; j < batch.length; j += 1) {
+          const repo = batch[j];
+          if (repo === undefined) {
+            continue;
+          }
+
+          const alias = `repo${j}`;
+          if (failedAliases.has(alias)) {
+            const error = gqlErrors.find((gqlError) => gqlError.path?.[0] === alias);
+            result.set(repo.fullName, new Error(error?.message ?? "GraphQL error"));
+            continue;
+          }
+
+          const node = responseData[alias] as GraphQLRepositoryNode | null | undefined;
+          if (node === null || node === undefined) {
+            result.set(repo.fullName, new Error(`Repository not found: ${repo.fullName}`));
+            continue;
+          }
+
+          result.set(repo.fullName, this.mapGraphQLNodeToDetails(node));
+        }
+      } catch (error) {
+        const batchError = error instanceof Error ? error : new Error(String(error));
+        for (const repo of batch) {
+          result.set(repo.fullName, batchError);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private buildBatchQuery(batch: SearchRepository[]): string {
+    const aliases = batch
+      .map((repository, index) => {
+        const [owner, name] = splitRepositoryFullName(repository.fullName);
+        return `
+      repo${index}: repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(name)}) {
+        forkCount
+        stargazerCount
+        watchers { totalCount }
+        primaryLanguage { name }
+        isTemplate
+        hasIssuesEnabled
+        latestRelease { name tagName url publishedAt }
+        repositoryTopics(first: 20) { nodes { topic { name } } }
+        languages(first: 20, orderBy: {field: SIZE, direction: DESC}) { nodes { name } }
+        codeOfConduct { key name url }
+        securityPolicyUrl
+        fundingLinks { platform url }
+        goodFirstIssues: issues(first: 1, states: OPEN, labels: ["good first issue"]) { totalCount }
+        helpWanted: issues(first: 1, states: OPEN, labels: ["help wanted"]) { totalCount }
+      }
+`;
+      })
+      .join("\n");
+
+    return `query BatchRepositoryDetails {\n  rateLimit { remaining resetAt }\n${aliases}}`;
+  }
+
+  private mapGraphQLNodeToDetails(node: GraphQLRepositoryNode): RepositoryDetails {
+    const openedGoodFirstIssues = node.hasIssuesEnabled ? node.goodFirstIssues.totalCount : 0;
+    const openedHelpWantedIssues = node.hasIssuesEnabled ? node.helpWanted.totalCount : 0;
+
+    return {
+      forkCount: node.forkCount,
+      stargazerCount: node.stargazerCount,
+      watchers: node.watchers,
+      primaryLanguage: mapPrimaryLanguage(node.primaryLanguage?.name ?? null),
+      isTemplate: node.isTemplate,
+      latestRelease:
+        node.latestRelease === null
+          ? null
+          : {
+              name: node.latestRelease.name ?? node.latestRelease.tagName,
+              tagName: node.latestRelease.tagName,
+              url: node.latestRelease.url,
+              publishedAt: node.latestRelease.publishedAt ?? ""
+            },
+      topics: node.repositoryTopics.nodes.map((topicNode) => topicNode.topic.name),
+      languages: node.languages.nodes.map((languageNode) => languageNode.name),
+      codeOfConduct:
+        node.codeOfConduct === null
+          ? null
+          : {
+              key: node.codeOfConduct.key,
+              name: node.codeOfConduct.name,
+              url: node.codeOfConduct.url
+            },
+      securityPolicyUrl: node.securityPolicyUrl,
+      isSecurityPolicyEnabled: node.securityPolicyUrl !== null,
+      fundingLinks: node.fundingLinks,
+      openedGoodFirstIssues,
+      hasGoodFirstIssues: openedGoodFirstIssues > 0,
+      openedHelpWantedIssues,
+      hasHelpWantedIssues: openedHelpWantedIssues > 0
     };
   }
 

--- a/Pipeline/src/providers.ts
+++ b/Pipeline/src/providers.ts
@@ -295,7 +295,13 @@ export class OctokitRepositoryProvider implements CandidateProvider {
 
           const node = responseData[alias] as GraphQLRepositoryNode | null | undefined;
           if (node === null || node === undefined) {
-            result.set(repo.fullName, new Error(`Repository not found: ${repo.fullName}`));
+            // Prefer root-level error message over generic "not found" so that the calling
+            // code can correctly classify PAT-policy errors (vs blocking data failures).
+            const missingError =
+              rootLevelErrors.length > 0
+                ? new Error(rootLevelErrors.map((e) => e.message).join("; "))
+                : new Error(`Repository not found: ${repo.fullName}`);
+            result.set(repo.fullName, missingError);
             continue;
           }
 

--- a/Pipeline/src/providers.ts
+++ b/Pipeline/src/providers.ts
@@ -248,7 +248,15 @@ export class OctokitRepositoryProvider implements CandidateProvider {
         const responseData = response.data.data ?? {};
         const gqlErrors = response.data.errors ?? [];
 
-        if (Object.keys(responseData).length === 0 && gqlErrors.length > 0) {
+        // Root-level errors (no path, or path not matching a repo alias) indicate a batch-wide failure
+        // (e.g. PAT-policy rejection arriving as a top-level GraphQL error without a repo path).
+        const rootLevelErrors = gqlErrors.filter(
+          (gqlError) => gqlError.path === undefined || gqlError.path === null || gqlError.path.length === 0
+        );
+        const aliasKeys = new Set(batch.map((_, j) => `repo${j}`));
+        const hasAnyRepoData = [...aliasKeys].some((alias) => responseData[alias] !== undefined);
+
+        if (!hasAnyRepoData && (rootLevelErrors.length > 0 || gqlErrors.length > 0)) {
           const batchError = new Error(gqlErrors.map((error) => error.message).join("; "));
           for (const repo of batch) {
             result.set(repo.fullName, batchError);
@@ -263,10 +271,11 @@ export class OctokitRepositoryProvider implements CandidateProvider {
           await new Promise((resolve) => setTimeout(resolve, waitMs));
         }
 
+        // Collect per-alias errors (errors with a path pointing to a specific repo alias)
         const failedAliases = new Set<string>();
         for (const gqlError of gqlErrors) {
           const alias = typeof gqlError.path?.[0] === "string" ? gqlError.path[0] : undefined;
-          if (alias !== undefined) {
+          if (alias !== undefined && aliasKeys.has(alias)) {
             failedAliases.add(alias);
           }
         }
@@ -290,7 +299,12 @@ export class OctokitRepositoryProvider implements CandidateProvider {
             continue;
           }
 
-          result.set(repo.fullName, this.mapGraphQLNodeToDetails(node));
+          // Catch per-repo mapping errors so one bad node doesn't poison the whole batch
+          try {
+            result.set(repo.fullName, this.mapGraphQLNodeToDetails(node));
+          } catch (mapError) {
+            result.set(repo.fullName, mapError instanceof Error ? mapError : new Error(String(mapError)));
+          }
         }
       } catch (error) {
         const batchError = error instanceof Error ? error : new Error(String(error));

--- a/Pipeline/src/types.ts
+++ b/Pipeline/src/types.ts
@@ -195,6 +195,7 @@ export interface Provenance {
 export interface CandidateProvider {
   searchRepositories(criterion: SearchCriterion): Promise<SearchRepository[]>;
   getRepositoryDetails(repositoryFullName: string, searchRepository: SearchRepository): Promise<RepositoryDetails>;
+  batchGetRepositoryDetails?(repos: SearchRepository[]): Promise<Map<string, RepositoryDetails | Error>>;
 }
 
 export interface PipelineMetrics {
@@ -205,6 +206,9 @@ export interface PipelineMetrics {
   activeRepositories: number;
   detailRequests: number;
   detailFailures: number;
+  patPolicyFailures: number;
+  patPolicyFailureNames: string[];
+  detailBatchCalls: number;
   generatedRecords: number;
   warnings: string[];
   elapsedMs: number;

--- a/Pipeline/tests/generator.test.ts
+++ b/Pipeline/tests/generator.test.ts
@@ -354,6 +354,56 @@ describe("generateRepositoryDetails", () => {
     expect(result.metrics.detailFailures).toBe(0);
   });
 
+  it("routes PAT-policy errors via error.cause.message to patPolicyFailures", async () => {
+    const configPath = path.join(outputRoot, "criteria-pat-cause.json");
+    const outputPath = path.join(outputRoot, "details-pat-cause.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 3 }]), "utf8");
+
+    const outerError = new Error("GitHub error") as Error & { cause: unknown };
+    outerError.cause = new Error("enterprise forbids access via a fine-grained personal access tokens");
+
+    const result = await generateRepositoryDetails({
+      configPath,
+      outputPath,
+      schemaPath,
+      provider: new FakeProvider(
+        { powerplatform: [searchRepository("owner/a"), searchRepository("owner/blocked")] },
+        { "owner/a": repositoryDetails(10), "owner/blocked": outerError }
+      ),
+      now: new Date("2026-01-01T00:00:00Z"),
+      workflowRunId: "test-run"
+    });
+
+    expect(result.metrics.patPolicyFailures).toBe(1);
+    expect(result.metrics.patPolicyFailureNames).toContain("owner/blocked");
+    expect(result.metrics.detailFailures).toBe(0);
+  });
+
+  it("routes PAT-policy errors via error.response.data.message to patPolicyFailures", async () => {
+    const configPath = path.join(outputRoot, "criteria-pat-response.json");
+    const outputPath = path.join(outputRoot, "details-pat-response.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 3 }]), "utf8");
+
+    const octokitError = new Error("Request failed") as Error & { response?: unknown };
+    octokitError.response = { data: { message: "fine-grained personal access tokens not permitted" } };
+
+    const result = await generateRepositoryDetails({
+      configPath,
+      outputPath,
+      schemaPath,
+      provider: new FakeProvider(
+        { powerplatform: [searchRepository("owner/a"), searchRepository("owner/blocked")] },
+        { "owner/a": repositoryDetails(10), "owner/blocked": octokitError }
+      ),
+      now: new Date("2026-01-01T00:00:00Z"),
+      workflowRunId: "test-run"
+    });
+
+    expect(result.metrics.patPolicyFailures).toBe(1);
+    expect(result.metrics.patPolicyFailureNames).toContain("owner/blocked");
+    expect(result.metrics.detailFailures).toBe(0);
+  });
+
   it("wraps search failures with topic context", async () => {
     const configPath = path.join(outputRoot, "criteria-search-error.json");
     const outputPath = path.join(outputRoot, "details-search-error.json");

--- a/Pipeline/tests/generator.test.ts
+++ b/Pipeline/tests/generator.test.ts
@@ -78,6 +78,47 @@ class FakeProvider implements CandidateProvider {
   }
 }
 
+class BatchFakeProvider implements CandidateProvider {
+  public batchCallCount = 0;
+
+  public constructor(
+    private readonly searchResults: Record<string, SearchRepository[]>,
+    private readonly detailResults: Record<string, RepositoryDetails | Error>
+  ) {}
+
+  public async searchRepositories(criterion: SearchCriterion): Promise<SearchRepository[]> {
+    return this.searchResults[criterion.topic] ?? [];
+  }
+
+  public async getRepositoryDetails(repositoryFullName: string): Promise<RepositoryDetails> {
+    const result = this.detailResults[repositoryFullName];
+    if (result === undefined) {
+      throw new Error(`No fixture for ${repositoryFullName}`);
+    }
+
+    if (result instanceof Error) {
+      throw result;
+    }
+
+    return result;
+  }
+
+  public async batchGetRepositoryDetails(repos: SearchRepository[]): Promise<Map<string, RepositoryDetails | Error>> {
+    this.batchCallCount += 1;
+    const map = new Map<string, RepositoryDetails | Error>();
+    for (const repo of repos) {
+      const result = this.detailResults[repo.fullName];
+      if (result === undefined) {
+        map.set(repo.fullName, new Error(`No fixture for ${repo.fullName}`));
+      } else {
+        map.set(repo.fullName, result);
+      }
+    }
+
+    return map;
+  }
+}
+
 describe("generateRepositoryDetails", () => {
   beforeEach(async () => {
     await rm(outputRoot, { recursive: true, force: true });
@@ -189,6 +230,128 @@ describe("generateRepositoryDetails", () => {
     expect(result.records.map((record) => record.fullName)).toEqual(["owner/keep"]);
     expect(result.metrics.detailFailures).toBe(1);
     expect(result.metrics.warnings.join("\n")).toContain("owner/fail");
+  });
+
+  it("routes PAT-policy 403 errors to patPolicyFailures metric (serial path)", async () => {
+    const configPath = path.join(outputRoot, "criteria-pat-policy.json");
+    const outputPath = path.join(outputRoot, "details-pat-policy.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 3 }]), "utf8");
+
+    const patError = new Error(
+      "The 'Microsoft Open Source' enterprise forbids access via a fine-grained personal access tokens if the token's lifetime is greater than 90 days."
+    );
+
+    const result = await generateRepositoryDetails({
+      configPath,
+      outputPath,
+      schemaPath,
+      provider: new FakeProvider(
+        { powerplatform: [searchRepository("owner/keep"), searchRepository("owner/pat-blocked")] },
+        { "owner/keep": repositoryDetails(15), "owner/pat-blocked": patError }
+      ),
+      now: new Date("2026-01-01T00:00:00Z"),
+      workflowRunId: "test-run"
+    });
+
+    expect(result.records.map((r) => r.fullName)).toEqual(["owner/keep"]);
+    expect(result.metrics.patPolicyFailures).toBe(1);
+    expect(result.metrics.patPolicyFailureNames).toContain("owner/pat-blocked");
+    expect(result.metrics.detailFailures).toBe(0);
+  });
+
+  it("routes non-PAT errors to detailFailures metric, not patPolicyFailures", async () => {
+    const configPath = path.join(outputRoot, "criteria-ordinary-error.json");
+    const outputPath = path.join(outputRoot, "details-ordinary-error.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 2 }]), "utf8");
+
+    const result = await generateRepositoryDetails({
+      configPath,
+      outputPath,
+      schemaPath,
+      provider: new FakeProvider(
+        { powerplatform: [searchRepository("owner/keep"), searchRepository("owner/fail")] },
+        { "owner/keep": repositoryDetails(15), "owner/fail": new Error("network timeout") }
+      ),
+      now: new Date("2026-01-01T00:00:00Z"),
+      workflowRunId: "test-run"
+    });
+
+    expect(result.metrics.detailFailures).toBe(1);
+    expect(result.metrics.patPolicyFailures).toBe(0);
+    expect(result.metrics.patPolicyFailureNames).toHaveLength(0);
+  });
+
+  it("uses batchGetRepositoryDetails when available and sets detailBatchCalls", async () => {
+    const configPath = path.join(outputRoot, "criteria-batch.json");
+    const outputPath = path.join(outputRoot, "details-batch.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 3 }]), "utf8");
+
+    const provider = new BatchFakeProvider(
+      { powerplatform: [searchRepository("owner/a"), searchRepository("owner/b")] },
+      { "owner/a": repositoryDetails(15), "owner/b": repositoryDetails(12) }
+    );
+
+    const result = await generateRepositoryDetails({
+      configPath,
+      outputPath,
+      schemaPath,
+      provider,
+      now: new Date("2026-01-01T00:00:00Z"),
+      workflowRunId: "test-run"
+    });
+
+    expect(result.records.map((r) => r.fullName)).toEqual(["owner/a", "owner/b"]);
+    expect(result.metrics.detailRequests).toBe(2);
+    expect(result.metrics.detailBatchCalls).toBeGreaterThan(0);
+    expect(result.metrics.detailFailures).toBe(0);
+    expect(provider.batchCallCount).toBe(1);
+  });
+
+  it("handles partial batch failure: failed repo goes to detailFailures, others succeed", async () => {
+    const configPath = path.join(outputRoot, "criteria-batch-partial.json");
+    const outputPath = path.join(outputRoot, "details-batch-partial.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 3 }]), "utf8");
+
+    const result = await generateRepositoryDetails({
+      configPath,
+      outputPath,
+      schemaPath,
+      provider: new BatchFakeProvider(
+        { powerplatform: [searchRepository("owner/ok"), searchRepository("owner/err")] },
+        { "owner/ok": repositoryDetails(20), "owner/err": new Error("GraphQL partial failure") }
+      ),
+      now: new Date("2026-01-01T00:00:00Z"),
+      workflowRunId: "test-run"
+    });
+
+    expect(result.records.map((r) => r.fullName)).toEqual(["owner/ok"]);
+    expect(result.metrics.detailFailures).toBe(1);
+    expect(result.metrics.patPolicyFailures).toBe(0);
+  });
+
+  it("routes PAT-policy errors in batch path to patPolicyFailures", async () => {
+    const configPath = path.join(outputRoot, "criteria-batch-pat.json");
+    const outputPath = path.join(outputRoot, "details-batch-pat.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 3 }]), "utf8");
+
+    const patError = new Error("enterprise forbids access via a fine-grained personal access tokens");
+
+    const result = await generateRepositoryDetails({
+      configPath,
+      outputPath,
+      schemaPath,
+      provider: new BatchFakeProvider(
+        { powerplatform: [searchRepository("owner/ok"), searchRepository("owner/pat-blocked")] },
+        { "owner/ok": repositoryDetails(15), "owner/pat-blocked": patError }
+      ),
+      now: new Date("2026-01-01T00:00:00Z"),
+      workflowRunId: "test-run"
+    });
+
+    expect(result.records.map((r) => r.fullName)).toEqual(["owner/ok"]);
+    expect(result.metrics.patPolicyFailures).toBe(1);
+    expect(result.metrics.patPolicyFailureNames).toContain("owner/pat-blocked");
+    expect(result.metrics.detailFailures).toBe(0);
   });
 
   it("wraps search failures with topic context", async () => {

--- a/Pipeline/tests/providers.test.ts
+++ b/Pipeline/tests/providers.test.ts
@@ -1,0 +1,290 @@
+import { OctokitRepositoryProvider } from "../src/providers.js";
+import type { GitHubClient } from "../src/providers.js";
+import type { SearchRepository } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function repo(fullName: string): SearchRepository {
+  const [login = "owner", name = fullName] = fullName.split("/");
+  return {
+    createdAt: "2024-01-01T00:00:00Z",
+    description: `Repo ${fullName}`,
+    fullName,
+    repositoryId: `id:${fullName}`,
+    hasIssues: true,
+    homepage: "",
+    isArchived: false,
+    language: "TypeScript",
+    license: { key: "mit", name: "MIT License", url: "https://api.github.com/licenses/mit" },
+    name,
+    openIssuesCount: 0,
+    owner: { id: "1", is_bot: false, login, type: "Organization", url: `https://github.com/${login}` },
+    updatedAt: "2026-01-01T00:00:00Z",
+    url: `https://github.com/${fullName}`
+  };
+}
+
+function goodNode(overrides: Record<string, unknown> = {}) {
+  return {
+    forkCount: 5,
+    stargazerCount: 100,
+    watchers: { totalCount: 20 },
+    primaryLanguage: { name: "TypeScript" },
+    isTemplate: false,
+    hasIssuesEnabled: true,
+    latestRelease: null,
+    repositoryTopics: { nodes: [{ topic: { name: "powerplatform" } }] },
+    languages: { nodes: [{ name: "TypeScript" }] },
+    codeOfConduct: null,
+    securityPolicyUrl: null,
+    fundingLinks: [],
+    goodFirstIssues: { totalCount: 2 },
+    helpWanted: { totalCount: 3 },
+    ...overrides
+  };
+}
+
+const FAR_FUTURE_RESET = new Date(Date.now() + 3_600_000).toISOString();
+const RATE_LIMIT_OK = { remaining: 5000, resetAt: FAR_FUTURE_RESET };
+
+function makeClient(responses: Array<Record<string, unknown>>): GitHubClient {
+  let callIndex = 0;
+  return {
+    rest: {} as GitHubClient["rest"],
+    request<T>(_route: string, _params: Record<string, unknown>): Promise<{ data: T }> {
+      const response = responses[callIndex] ?? {};
+      callIndex += 1;
+      return Promise.resolve({ data: response as T });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// batchGetRepositoryDetails — happy path
+// ---------------------------------------------------------------------------
+
+describe("OctokitRepositoryProvider.batchGetRepositoryDetails", () => {
+  it("maps a successful GraphQL response to RepositoryDetails for each repo", async () => {
+    const node = goodNode();
+    const client = makeClient([
+      {
+        data: {
+          rateLimit: RATE_LIMIT_OK,
+          repo0: node,
+          repo1: goodNode({ stargazerCount: 42 })
+        },
+        errors: []
+      }
+    ]);
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails([repo("owner/a"), repo("owner/b")]);
+
+    const a = results.get("owner/a");
+    const b = results.get("owner/b");
+
+    expect(a).not.toBeInstanceOf(Error);
+    expect(b).not.toBeInstanceOf(Error);
+
+    if (!(a instanceof Error) && a !== undefined) {
+      expect(a.stargazerCount).toBe(100);
+      expect(a.forkCount).toBe(5);
+      expect(a.topics).toEqual(["powerplatform"]);
+      expect(a.languages).toEqual(["TypeScript"]);
+      expect(a.openedGoodFirstIssues).toBe(2);
+      expect(a.hasGoodFirstIssues).toBe(true);
+      expect(a.openedHelpWantedIssues).toBe(3);
+      expect(a.hasHelpWantedIssues).toBe(true);
+    }
+
+    if (!(b instanceof Error) && b !== undefined) {
+      expect(b.stargazerCount).toBe(42);
+    }
+  });
+
+  it("maps hasIssuesEnabled=false to zero issue counts", async () => {
+    const client = makeClient([
+      {
+        data: {
+          rateLimit: RATE_LIMIT_OK,
+          repo0: goodNode({ hasIssuesEnabled: false, goodFirstIssues: { totalCount: 99 }, helpWanted: { totalCount: 99 } })
+        },
+        errors: []
+      }
+    ]);
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails([repo("owner/a")]);
+    const a = results.get("owner/a");
+
+    expect(a).not.toBeInstanceOf(Error);
+    if (!(a instanceof Error) && a !== undefined) {
+      expect(a.openedGoodFirstIssues).toBe(0);
+      expect(a.hasGoodFirstIssues).toBe(false);
+      expect(a.openedHelpWantedIssues).toBe(0);
+      expect(a.hasHelpWantedIssues).toBe(false);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Per-alias GraphQL errors
+  // ---------------------------------------------------------------------------
+
+  it("maps a per-alias GraphQL error to Error for that repo only", async () => {
+    const client = makeClient([
+      {
+        data: {
+          rateLimit: RATE_LIMIT_OK,
+          repo0: goodNode()
+          // repo1 deliberately absent — covered by per-alias error below
+        },
+        errors: [{ message: "Could not resolve to a Repository", path: ["repo1"] }]
+      }
+    ]);
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails([repo("owner/ok"), repo("owner/bad")]);
+
+    expect(results.get("owner/ok")).not.toBeInstanceOf(Error);
+    const bad = results.get("owner/bad");
+    expect(bad).toBeInstanceOf(Error);
+    expect((bad as Error).message).toContain("Could not resolve to a Repository");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Root-level GraphQL errors (PAT-policy scenario)
+  // ---------------------------------------------------------------------------
+
+  it("applies root-level error to all repos when no repo data is present", async () => {
+    const patMessage =
+      "The 'Microsoft Open Source' enterprise forbids access via a fine-grained personal access tokens if the token's lifetime is greater than 90 days.";
+
+    const client = makeClient([
+      {
+        data: { rateLimit: RATE_LIMIT_OK },
+        errors: [{ message: patMessage }] // no path = root-level error
+      }
+    ]);
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails([repo("owner/a"), repo("owner/b")]);
+
+    for (const fullName of ["owner/a", "owner/b"]) {
+      const r = results.get(fullName);
+      expect(r).toBeInstanceOf(Error);
+      expect((r as Error).message).toContain("fine-grained personal access tokens");
+    }
+  });
+
+  it("applies root-level error to missing repos even when some repos have data (partial batch)", async () => {
+    const patMessage = "enterprise forbids access via a fine-grained personal access tokens";
+
+    const client = makeClient([
+      {
+        data: {
+          rateLimit: RATE_LIMIT_OK,
+          repo0: goodNode() // repo0 succeeds
+          // repo1 absent — should get root-level error, NOT "Repository not found"
+        },
+        errors: [{ message: patMessage }]
+      }
+    ]);
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails([repo("owner/ok"), repo("owner/blocked")]);
+
+    // repo0 (owner/ok) should still succeed
+    expect(results.get("owner/ok")).not.toBeInstanceOf(Error);
+
+    // repo1 (owner/blocked) should carry the root-level PAT error message, not "not found"
+    const blocked = results.get("owner/blocked");
+    expect(blocked).toBeInstanceOf(Error);
+    expect((blocked as Error).message).toContain("fine-grained personal access tokens");
+    expect((blocked as Error).message).not.toContain("Repository not found");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Per-alias mapping error isolation
+  // ---------------------------------------------------------------------------
+
+  it("isolates mapGraphQLNodeToDetails errors so one bad node does not fail the whole batch", async () => {
+    // A node where repositoryTopics is null will cause .nodes access to throw
+    const malformedNode = goodNode({ repositoryTopics: null });
+
+    const client = makeClient([
+      {
+        data: {
+          rateLimit: RATE_LIMIT_OK,
+          repo0: goodNode(), // fine
+          repo1: malformedNode // will throw inside mapGraphQLNodeToDetails
+        },
+        errors: []
+      }
+    ]);
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails([repo("owner/good"), repo("owner/bad")]);
+
+    expect(results.get("owner/good")).not.toBeInstanceOf(Error);
+    expect(results.get("owner/bad")).toBeInstanceOf(Error);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multiple batches (> 20 repos)
+  // ---------------------------------------------------------------------------
+
+  it("splits repos into batches of 20 and makes one request per batch", async () => {
+    const repoList = Array.from({ length: 21 }, (_, i) => repo(`owner/repo${i}`));
+
+    let callCount = 0;
+
+    const multiClient: GitHubClient = {
+      rest: {} as GitHubClient["rest"],
+      request<T>(_route: string, params: Record<string, unknown>): Promise<{ data: T }> {
+        callCount += 1;
+        const query = params["query"] as string;
+
+        // First call: 20 repos (repo0–repo19), second call: 1 repo (repo0)
+        const aliasCount = (query.match(/repo\d+:/g) ?? []).length;
+
+        const aliases: Record<string, unknown> = { rateLimit: RATE_LIMIT_OK };
+        for (let i = 0; i < aliasCount; i += 1) {
+          aliases[`repo${i}`] = goodNode({ stargazerCount: callCount * 10 + i });
+        }
+
+        return Promise.resolve({ data: { data: aliases, errors: [] } as T });
+      }
+    };
+
+    const provider = new OctokitRepositoryProvider(multiClient);
+    const results = await provider.batchGetRepositoryDetails(repoList);
+
+    expect(callCount).toBe(2); // 20 + 1
+    expect(results.size).toBe(21);
+    for (const r of repoList) {
+      expect(results.get(r.fullName)).not.toBeInstanceOf(Error);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge case: null node in data (repo exists but is null — e.g. private repo)
+  // ---------------------------------------------------------------------------
+
+  it("records 'Repository not found' error for a null node with no root-level errors", async () => {
+    const client = makeClient([
+      {
+        data: { rateLimit: RATE_LIMIT_OK, repo0: null },
+        errors: []
+      }
+    ]);
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails([repo("owner/private")]);
+
+    const r = results.get("owner/private");
+    expect(r).toBeInstanceOf(Error);
+    expect((r as Error).message).toContain("Repository not found");
+  });
+});


### PR DESCRIPTION
## Summary

This PR addresses two issues in the \1-update-github-repositories-details\ workflow:

### Problem 1 — Pipeline blocked by PAT policy failures

7 repositories fail detail hydration because \PAT_ACCESS_PUBLIC_GITHUB_REPOSITORIES\ is a fine-grained PAT with lifetime > 90 days, which violates enterprise policies for:
- \Azure-Samples/*\ and \Azure/*\ repos (Microsoft Open Source enterprise: max 90-day lifetime)
- \PowerPlatformAF/PowerPlatformAF\ (max 366-day lifetime)

**Code fix:** Classify PAT policy 403 errors separately from genuine data failures. The pipeline now emits \::warning::\ annotations for PAT-policy-blocked repos and continues without blocking.

> ⚠️ **Recommended parallel action**: Replace the \PAT_ACCESS_PUBLIC_GITHUB_REPOSITORIES\ secret with a **classic PAT** (\public_repo\ scope). Classic PATs are not subject to enterprise fine-grained PAT lifetime restrictions. This prevents those 7 repos from being skipped in the output.

### Problem 2 — 43-minute runtime

\OctokitRepositoryProvider.getRepositoryDetails\ makes 7 REST API calls per repo:
- 5 parallel REST calls + 1 serial
- 2 Search API calls for issue counts (Search API: 30 req/min → 480 calls = 16+ minutes)

**Fix:** Replace all per-repo REST calls with GitHub GraphQL batching (20 repos per batch, ~12 requests for 240 repos). Uses existing Octokit client with \POST /graphql\ to preserve the throttle/retry behavior. Expected runtime: **3–5 minutes** (down from 43 minutes).

## Files changed

| File | Change |
|---|---|
| \Pipeline/src/types.ts\ | Add \patPolicyFailures\, \patPolicyFailureNames\, \detailBatchCalls\ to \PipelineMetrics\; add optional \atchGetRepositoryDetails\ to \CandidateProvider\ |
| \Pipeline/src/generator.ts\ | Multi-source PAT policy classifier; batch hydration path with per-repo metric updates |
| \Pipeline/src/providers.ts\ | Implement \atchGetRepositoryDetails\ with GraphQL alias queries |
| \.github/workflows/update-github-repositories-details.yml\ | Guard: block on \detailFailures\ only; warn on \patPolicyFailures\ |
| \Pipeline/tests/generator.test.ts\ | Tests for PAT policy metric, batch path, partial batch errors |

## Testing

- [ ] All unit tests pass (\cd Pipeline && npm test\)
- [ ] Build succeeds (\cd Pipeline && npm run build\)