### PR TITLE
fix(pipeline): fall back to REST for silent null GraphQL nodes (microsoft org)

### DIFF
--- a/Pipeline/src/providers.ts
+++ b/Pipeline/src/providers.ts
@@ -294,14 +294,31 @@ export class OctokitRepositoryProvider implements CandidateProvider {
           }
 
           const node = responseData[alias] as GraphQLRepositoryNode | null | undefined;
-          if (node === null || node === undefined) {
-            // Prefer root-level error message over generic "not found" so that the calling
-            // code can correctly classify PAT-policy errors (vs blocking data failures).
-            const missingError =
-              rootLevelErrors.length > 0
-                ? new Error(rootLevelErrors.map((e) => e.message).join("; "))
-                : new Error(`Repository not found: ${repo.fullName}`);
-            result.set(repo.fullName, missingError);
+          if (node === undefined || node === null) {
+            if (rootLevelErrors.length > 0) {
+              // Root-level error present: propagate its message so the caller can classify
+              // PAT-policy errors (vs. blocking data failures). Applies to both the
+              // Azure-Samples/Azure pattern (alias absent = undefined) and cases where
+              // GraphQL explicitly returns null alongside a root-level error.
+              result.set(repo.fullName, new Error(rootLevelErrors.map((e) => e.message).join("; ")));
+            } else if (node === undefined) {
+              // Alias absent with no error — unexpected, likely a malformed response.
+              result.set(repo.fullName, new Error(`GraphQL response missing alias '${alias}' for ${repo.fullName}`));
+            } else {
+              // GraphQL returned null with no error. All repos in this batch were found by the
+              // search API so they exist. GitHub can silently null-out repos for PAT-policy
+              // restrictions without surfacing an explicit GraphQL error (behaviour differs by
+              // org). Fall back to REST — getRepositoryDetails() calls repos.get first, so a
+              // 403 PAT-policy error surfaces immediately and can be classified by the caller.
+              try {
+                result.set(repo.fullName, await this.getRepositoryDetails(repo.fullName, repo));
+              } catch (fallbackError) {
+                result.set(
+                  repo.fullName,
+                  fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError))
+                );
+              }
+            }
             continue;
           }
 

--- a/Pipeline/tests/providers.test.ts
+++ b/Pipeline/tests/providers.test.ts
@@ -269,22 +269,112 @@ describe("OctokitRepositoryProvider.batchGetRepositoryDetails", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Edge case: null node in data (repo exists but is null — e.g. private repo)
+  // Edge case: null node in data (GitHub silently returns null for PAT-restricted repos)
   // ---------------------------------------------------------------------------
 
-  it("records 'Repository not found' error for a null node with no root-level errors", async () => {
+  it("falls back to REST and surfaces PAT error when GraphQL returns null with no root-level errors", async () => {
+    const patMessage =
+      "The 'Microsoft Open Source' enterprise forbids access via a fine-grained personal access tokens if the token's lifetime is greater than 90 days.";
+
+    let graphqlCalled = false;
+    const client: GitHubClient = {
+      rest: {
+        repos: {
+          get: () => {
+            const err = Object.assign(new Error(patMessage), { status: 403 });
+            return Promise.reject(err);
+          },
+          getAllTopics: () => Promise.resolve({ data: { names: [] } }),
+          listLanguages: () => Promise.resolve({ data: {} }),
+          getLatestRelease: () => {
+            const err = Object.assign(new Error("Not Found"), { status: 404 });
+            return Promise.reject(err);
+          }
+        },
+        search: {
+          repos: () => Promise.resolve({ data: { items: [] } }),
+          issuesAndPullRequests: () => Promise.resolve({ data: { total_count: 0 } })
+        }
+      } as unknown as GitHubClient["rest"],
+      request<T>(route: string): Promise<{ data: T }> {
+        if (route === "POST /graphql") {
+          graphqlCalled = true;
+          return Promise.resolve({
+            data: { data: { rateLimit: RATE_LIMIT_OK, repo0: null }, errors: [] } as T
+          });
+        }
+        // community/code_of_conduct, community/profile
+        return Promise.resolve({ data: {} as T });
+      }
+    };
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails([repo("microsoft/PowerApps-Samples")]);
+
+    expect(graphqlCalled).toBe(true);
+    const r = results.get("microsoft/PowerApps-Samples");
+    expect(r).toBeInstanceOf(Error);
+    expect((r as Error).message).toContain("fine-grained personal access tokens");
+  });
+
+  it("falls back to REST and returns RepositoryDetails when GraphQL returns null with no root-level errors", async () => {
+    const client: GitHubClient = {
+      rest: {
+        repos: {
+          get: () =>
+            Promise.resolve({
+              data: { forks_count: 10, stargazers_count: 50, has_issues: false, is_template: false, subscribers_count: 5 }
+            }),
+          getAllTopics: () => Promise.resolve({ data: { names: ["powerplatform"] } }),
+          listLanguages: () => Promise.resolve({ data: { TypeScript: 1 } }),
+          getLatestRelease: () => {
+            const err = Object.assign(new Error("Not Found"), { status: 404 });
+            return Promise.reject(err);
+          }
+        },
+        search: {
+          repos: () => Promise.resolve({ data: { items: [] } }),
+          issuesAndPullRequests: () => Promise.resolve({ data: { total_count: 0 } })
+        }
+      } as unknown as GitHubClient["rest"],
+      request<T>(route: string): Promise<{ data: T }> {
+        if (route === "POST /graphql") {
+          return Promise.resolve({
+            data: { data: { rateLimit: RATE_LIMIT_OK, repo0: null }, errors: [] } as T
+          });
+        }
+        return Promise.resolve({ data: {} as T });
+      }
+    };
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails([repo("owner/a")]);
+
+    const r = results.get("owner/a");
+    expect(r).not.toBeInstanceOf(Error);
+    if (!(r instanceof Error) && r !== undefined) {
+      expect(r.forkCount).toBe(10);
+      expect(r.stargazerCount).toBe(50);
+      expect(r.topics).toEqual(["powerplatform"]);
+    }
+  });
+
+  it("records a missing-alias error for an absent alias in the GraphQL response with no errors", async () => {
+    // repo0 key is completely absent from data (not null) and there are no errors.
+    // This indicates an unexpected/malformed response rather than a PAT restriction.
     const client = makeClient([
       {
-        data: { rateLimit: RATE_LIMIT_OK, repo0: null },
+        data: { rateLimit: RATE_LIMIT_OK }, // no repo0 key at all
         errors: []
       }
     ]);
 
     const provider = new OctokitRepositoryProvider(client);
-    const results = await provider.batchGetRepositoryDetails([repo("owner/private")]);
+    const results = await provider.batchGetRepositoryDetails([repo("owner/a")]);
 
-    const r = results.get("owner/private");
+    const r = results.get("owner/a");
     expect(r).toBeInstanceOf(Error);
-    expect((r as Error).message).toContain("Repository not found");
+    expect((r as Error).message).toContain("missing alias");
+    expect((r as Error).message).not.toContain("Repository not found");
   });
 });


### PR DESCRIPTION
## Problem

After PR #62, the workflow still failed with 20 detailFailures for microsoft/* repos.

Root cause: GitHub GraphQL API behaves inconsistently for fine-grained PAT restrictions:
- Azure-Samples/Azure orgs: root-level GraphQL error with PAT-policy message (already handled by PR #62)
- microsoft org: silently returns null for the repo node with NO error (not handled, fell through to detailFailures, pipeline blocked)

## Fix

In batchGetRepositoryDetails, when GraphQL returns null for a repo node with no root-level error, fall back to getRepositoryDetails() (REST). Since getRepositoryDetails() calls repos.get first:
- REST returns 403 PAT policy: error with PAT message, isPatPolicyError() classifies it as patPolicyFailures (warning, not blocking)
- REST succeeds: data is used directly

The undefined alias path now also checks rootLevelErrors first, covering Azure-Samples where PAT restrictions surface as undefined aliases alongside root-level errors.

## Tests added
- Null node + REST returns 403 PAT error -> error contains PAT policy message
- Null node + REST succeeds -> RepositoryDetails returned
- Absent alias + no errors -> missing alias error

Tests: 59/59 passing