### PR TITLE
fix(pipeline): REST fallback for GraphQL batch-level failures (502/timeout)

### DIFF
--- a/Pipeline/src/githubClient.ts
+++ b/Pipeline/src/githubClient.ts
@@ -17,7 +17,10 @@ export function createGitHubClient(authToken: string): GitHubClient {
         const request = options.request as { retryCount?: number };
         return (request.retryCount ?? 0) < 2;
       },
-      onSecondaryRateLimit: () => false
+      onSecondaryRateLimit: (_retryAfter, options) => {
+        const request = options.request as { retryCount?: number };
+        return (request.retryCount ?? 0) < 2;
+      }
     }
   }) as unknown as GitHubClient;
 }

--- a/Pipeline/src/providers.ts
+++ b/Pipeline/src/providers.ts
@@ -329,10 +329,18 @@ export class OctokitRepositoryProvider implements CandidateProvider {
             result.set(repo.fullName, mapError instanceof Error ? mapError : new Error(String(mapError)));
           }
         }
-      } catch (error) {
-        const batchError = error instanceof Error ? error : new Error(String(error));
+      } catch (batchLevelError) {
+        // The entire GraphQL batch failed (e.g. 502 Bad Gateway due to query complexity on
+        // large repos, network timeout, etc.). Fall back to individual REST calls so one
+        // failing batch does not poison all 20 repos at once. With a classic PAT, REST
+        // succeeds for all public repos; PAT-policy errors from REST are still classified
+        // by the caller via isPatPolicyError().
         for (const repo of batch) {
-          result.set(repo.fullName, batchError);
+          try {
+            result.set(repo.fullName, await this.getRepositoryDetails(repo.fullName, repo));
+          } catch (restError) {
+            result.set(repo.fullName, restError instanceof Error ? restError : new Error(String(restError)));
+          }
         }
       }
     }

--- a/Pipeline/tests/providers.test.ts
+++ b/Pipeline/tests/providers.test.ts
@@ -61,6 +61,55 @@ function makeClient(responses: Array<Record<string, unknown>>): GitHubClient {
   };
 }
 
+function makeRestFallbackClient(options: { graphqlError?: Error; restRepoError?: Error } = {}): {
+  client: GitHubClient;
+  repoGetCalls: string[];
+} {
+  const repoGetCalls: string[] = [];
+  const graphqlError = options.graphqlError ?? Object.assign(new Error("Bad Gateway"), { status: 502 });
+
+  return {
+    repoGetCalls,
+    client: {
+      rest: {
+        repos: {
+          get: ({ owner, repo }) => {
+            const fullName = `${owner}/${repo}`;
+            repoGetCalls.push(fullName);
+            if (options.restRepoError !== undefined) {
+              return Promise.reject(options.restRepoError);
+            }
+            return Promise.resolve({
+              data: {
+                forks_count: 10,
+                stargazers_count: repoGetCalls.length * 100,
+                has_issues: true,
+                is_template: false,
+                language: "TypeScript",
+                subscribers_count: 5
+              }
+            });
+          },
+          getAllTopics: () => Promise.resolve({ data: { names: ["powerplatform"] } }),
+          listLanguages: () => Promise.resolve({ data: { TypeScript: 1 } }),
+          getLatestRelease: () => Promise.reject(Object.assign(new Error("Not Found"), { status: 404 }))
+        },
+        search: {
+          repos: () => Promise.resolve({ data: { items: [] } }),
+          issuesAndPullRequests: () => Promise.resolve({ data: { total_count: 0 } })
+        }
+      } as GitHubClient["rest"],
+      request<T>(route: string): Promise<{ data: T }> {
+        if (route === "POST /graphql") {
+          return Promise.reject(graphqlError);
+        }
+
+        return Promise.resolve({ data: {} as T });
+      }
+    }
+  };
+}
+
 // ---------------------------------------------------------------------------
 // batchGetRepositoryDetails — happy path
 // ---------------------------------------------------------------------------
@@ -356,6 +405,45 @@ describe("OctokitRepositoryProvider.batchGetRepositoryDetails", () => {
       expect(r.forkCount).toBe(10);
       expect(r.stargazerCount).toBe(50);
       expect(r.topics).toEqual(["powerplatform"]);
+    }
+  });
+
+  it("falls back to REST for each repo when the entire GraphQL batch fails", async () => {
+    const { client, repoGetCalls } = makeRestFallbackClient();
+    const repoList = [repo("owner/a"), repo("owner/b"), repo("owner/c")];
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails(repoList);
+
+    expect(repoGetCalls).toEqual(["owner/a", "owner/b", "owner/c"]);
+    for (const repository of repoList) {
+      const details = results.get(repository.fullName);
+      expect(details).not.toBeInstanceOf(Error);
+      if (!(details instanceof Error) && details !== undefined) {
+        expect(details.topics).toEqual(["powerplatform"]);
+        expect(details.languages).toEqual(["TypeScript"]);
+      }
+    }
+  });
+
+  it("records the REST fallback error when the entire GraphQL batch fails", async () => {
+    const patError = Object.assign(
+      new Error(
+        "The 'Microsoft Open Source' enterprise forbids access via a fine-grained personal access tokens if the token's lifetime is greater than 90 days."
+      ),
+      { status: 403 }
+    );
+    const { client, repoGetCalls } = makeRestFallbackClient({ restRepoError: patError });
+    const repoList = [repo("microsoft/PowerApps-Samples"), repo("microsoft/PowerPlatformConnectors")];
+
+    const provider = new OctokitRepositoryProvider(client);
+    const results = await provider.batchGetRepositoryDetails(repoList);
+
+    expect(repoGetCalls).toEqual(["microsoft/PowerApps-Samples", "microsoft/PowerPlatformConnectors"]);
+    for (const repository of repoList) {
+      const details = results.get(repository.fullName);
+      expect(details).toBeInstanceOf(Error);
+      expect((details as Error).message).toContain("fine-grained personal access tokens");
     }
   });
 


### PR DESCRIPTION
## Summary
- fall back to per-repo REST hydration when an entire GraphQL batch request fails
- keep recording REST errors per repository so PAT-policy failures are still classified downstream
- add regression coverage for successful REST fallback and REST fallback failure cases

## Root cause
Large Microsoft org repositories can make the batched `POST /graphql` request fail at the transport level (for example `502 Bad Gateway` or timeouts). The previous outer `catch` recorded that single batch error for every repo in the 20-repo batch, so all 20 became `detailFailures` and blocked the pipeline.

## Fix
When the whole GraphQL batch throws, `batchGetRepositoryDetails` now falls back to `getRepositoryDetails()` for each repo in the batch. That isolates failures to the repos that truly fail under REST while allowing public repos to continue through the pipeline.

## Validation
- `cd Pipeline && npm test`
- `cd Pipeline && npm run typecheck`