### PR TITLE
feat: UI/UX improvements across website

### DIFF
--- a/Website/docs/community/contribute-to-projects.md
+++ b/Website/docs/community/contribute-to-projects.md
@@ -23,3 +23,10 @@ Look for repositories that match your skills and interests. Good first contribut
 4. Keep changes focused so maintainers can review them confidently.
 
 Each project in the hub is maintained by its own community. Be respectful of the maintainers' time and the project's scope.
+
+## Find a project to contribute to
+
+Use the hub's filters to narrow down repositories by contribution signals:
+
+- [Browse repositories with good first issues](https://rpothin.github.io/PowerPlatform-OpenSource-Hub/?goodFirstIssue=true)
+- [Browse repositories with help-wanted issues](https://rpothin.github.io/PowerPlatform-OpenSource-Hub/?helpWantedIssue=true)

--- a/Website/docs/community/find-solutions.md
+++ b/Website/docs/community/find-solutions.md
@@ -20,3 +20,10 @@ Use the hub when you need Power Platform or Copilot Studio open-source projects 
 - A license that fits your intended use.
 
 If you find a useful repository that is missing from the hub, consider inviting its maintainers or pointing them to the repository listing guidance.
+
+## Explore the hub
+
+Ready to search?
+
+- [Browse all repositories](https://rpothin.github.io/PowerPlatform-OpenSource-Hub/) — use search and filters to find what you need.
+- [Browse repositories with good first issues](https://rpothin.github.io/PowerPlatform-OpenSource-Hub/?goodFirstIssue=true) — jump straight to repositories welcoming new contributors.

--- a/Website/docs/community/index.md
+++ b/Website/docs/community/index.md
@@ -13,3 +13,5 @@ Use this section based on what you want to do next:
 - [List your repository](./list-your-repository.md) when you maintain a project that should appear in the hub.
 
 The hub is powered by public GitHub metadata, topic-based discovery, and curated repository information. It is meant to make relevant projects easier to find, compare, and support—not to replace each project's own documentation, issues, or contribution process.
+
+→ **[Open the hub](https://rpothin.github.io/PowerPlatform-OpenSource-Hub/)** to start exploring.

--- a/Website/docs/intro.md
+++ b/Website/docs/intro.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Power Platform Open-Source Hub Presentation
 
-Accross this section, you will discover a bit more about the Power Platform Open-Source Hub initiative.
+Across this section, you will discover a bit more about the Power Platform Open-Source Hub initiative.
 
 ## Why this initiative?
 

--- a/Website/docs/repository-onboarding/self-onboarding.md
+++ b/Website/docs/repository-onboarding/self-onboarding.md
@@ -10,7 +10,7 @@ This guide will help you configure your GitHub repository to be part of the Powe
 
 ## Prerequisites
 
-To be able to onboard a repository into the initative you need to have the permission to add topics to it.
+To be able to onboard a repository into the initiative you need to have the permission to add topics to it.
 
 If you are not a maintainer of the repository, you can follow the [Invitation to Join](./invitation-to-join.md) procedure and ask the maintainer(s) to complete the process.
 
@@ -24,7 +24,7 @@ If you are not a maintainer of the repository, you can follow the [Invitation to
 
 That's it for the actions on your side!
 
-Now we will just need to wait for a maximum of 24 hours for the repository to be added to the Power Platform Open-Source Hub initative and be visible on the website.
+Now we will just need to wait for a maximum of 24 hours for the repository to be added to the Power Platform Open-Source Hub initiative and be visible on the website.
 
 ## Repository metadata and curation
 

--- a/Website/docusaurus.config.ts
+++ b/Website/docusaurus.config.ts
@@ -71,11 +71,13 @@ const config: Config = {
     },
   ],
 
+  plugins: [],
+
   themeConfig: {
     // Replace with your project's social card
     image: 'img/docusaurus-social-card.jpg',
     navbar: {
-      title: 'PP OSS Hub',
+      title: 'Power Platform OSS Hub',
       logo: {
         alt: 'Power Platform Open-Source Hub Logo',
         src: 'img/PowerPlatform_scalable.svg',

--- a/Website/package-lock.json
+++ b/Website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
+        "@docusaurus/plugin-client-redirects": "^3.10.1",
         "@docusaurus/plugin-content-docs": "^3.10.1",
         "@docusaurus/preset-classic": "^3.10.1",
         "@docusaurus/theme-common": "^3.10.1",
@@ -3862,6 +3863,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz",
+      "integrity": "sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/Website/package.json
+++ b/Website/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.1",
+    "@docusaurus/plugin-client-redirects": "^3.10.1",
     "@docusaurus/plugin-content-docs": "^3.10.1",
     "@docusaurus/preset-classic": "^3.10.1",
     "@docusaurus/theme-common": "^3.10.1",

--- a/Website/src/components/FilterPane/index.tsx
+++ b/Website/src/components/FilterPane/index.tsx
@@ -300,6 +300,7 @@ const FilterPane = ({
                 {showAllTopics ? (
                   <>
                     <Input
+                      aria-label="Search topics"
                       placeholder="Search topics…"
                       value={topicSearch}
                       onChange={(_, data) => setTopicSearch(data.value)}
@@ -405,6 +406,7 @@ const FilterPane = ({
               {showAllOwners ? (
                 <>
                   <Input
+                    aria-label="Search owners"
                     placeholder="Search owners…"
                     value={ownerSearch}
                     onChange={(_, data) => setOwnerSearch(data.value)}

--- a/Website/src/components/FilterPane/index.tsx
+++ b/Website/src/components/FilterPane/index.tsx
@@ -8,6 +8,7 @@ import {
   AccordionPanel,
   Button,
   Checkbox,
+  Input,
 } from "@fluentui/react-components";
 import type { CheckboxProps } from "@fluentui/react-components";
 
@@ -37,6 +38,8 @@ type FilterPaneProps = {
   onCategoriesChange: (values: string[]) => void;
   onFocusAreasChange: (values: string[]) => void;
   onAudiencesChange: (values: string[]) => void;
+  onClearAllFilters?: () => void;
+  hasAnyActiveFilters?: boolean;
 };
 
 const FilterPane = ({
@@ -62,11 +65,15 @@ const FilterPane = ({
   onCategoriesChange,
   onFocusAreasChange,
   onAudiencesChange,
+  onClearAllFilters,
+  hasAnyActiveFilters = false,
 }: FilterPaneProps) => {
   const [showAllTopics, setShowAllTopics] = useState(false);
+  const [topicSearch, setTopicSearch] = useState('');
   const [showAllLanguages, setShowAllLanguages] = useState(false);
   const [showAllLicenses, setShowAllLicenses] = useState(false);
   const [showAllOwners, setShowAllOwners] = useState(false);
+  const [ownerSearch, setOwnerSearch] = useState('');
   const [showAllCategories, setShowAllCategories] = useState(false);
   const [showAllFocusAreas, setShowAllFocusAreas] = useState(false);
   const [showAllAudiences, setShowAllAudiences] = useState(false);
@@ -158,29 +165,47 @@ const FilterPane = ({
         minWidth: isMobile ? '100%' : '350px',
       }}
     >
+      {hasAnyActiveFilters && onClearAllFilters && (
+        <div style={{ padding: '8px 0', marginBottom: '8px', borderBottom: '1px solid var(--ifm-color-emphasis-300)' }}>
+          <Button
+            appearance="secondary"
+            size="small"
+            onClick={onClearAllFilters}
+            style={{ width: '100%' }}
+          >
+            Clear all filters
+          </Button>
+        </div>
+      )}
       <AccordionItem value="1">
-        <AccordionHeader style={{ marginBottom: '10px' }} size="large" expandIconPosition="end">Contribution Opportunities</AccordionHeader>
+        <AccordionHeader style={{ marginBottom: '10px' }} size="large" expandIconPosition="end">Repository Signals</AccordionHeader>
         <AccordionPanel>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <Checkbox 
-              id="checkbox-r-good-first-issue"
-              label={"Has good first issue (" + goodFirstIssueCount +  ")"}
-              checked={hasGoodFirstIssueChecked}
-              onChange={(_, data) => onGoodFirstIssueChange(data.checked === true)}
-            />
-            <Checkbox 
-              id="checkbox-r-help-wanted-issue"
-              label={"Has help wanted issue (" + helpWantedIssueCount + ")"} 
-              checked={hasHelpWantedIssueChecked}
-              onChange={(_, data) => onHelpWantedIssueChange(data.checked === true)}
-            />
-            <Checkbox 
-              id="checkbox-r-code-of-conduct"
-              label={"Has code of conduct (" + codeOfConductCount +  ")"} 
-              checked={hasCodeOfConductChecked}
-              onChange={(_, data) => onCodeOfConductChange(data.checked === true)}
-            />
-          </div>
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            <li style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+              <Checkbox 
+                id="checkbox-r-good-first-issue"
+                label={"Has good first issue (" + goodFirstIssueCount +  ")"}
+                checked={hasGoodFirstIssueChecked}
+                onChange={(_, data) => onGoodFirstIssueChange(data.checked === true)}
+              />
+            </li>
+            <li style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+              <Checkbox 
+                id="checkbox-r-help-wanted-issue"
+                label={"Has help wanted issue (" + helpWantedIssueCount + ")"} 
+                checked={hasHelpWantedIssueChecked}
+                onChange={(_, data) => onHelpWantedIssueChange(data.checked === true)}
+              />
+            </li>
+            <li style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+              <Checkbox 
+                id="checkbox-r-code-of-conduct"
+                label={"Has code of conduct (" + codeOfConductCount +  ")"} 
+                checked={hasCodeOfConductChecked}
+                onChange={(_, data) => onCodeOfConductChange(data.checked === true)}
+              />
+            </li>
+          </ul>
         </AccordionPanel>
       </AccordionItem>
       {categories.length > 0 && (
@@ -189,17 +214,18 @@ const FilterPane = ({
           <AccordionPanel>
             <div style={{ display: 'flex', flexDirection: 'column' }}>
               <div style={{ display: 'flex', flexDirection: 'column', rowGap: '10px' }}>
-                <div>
+                <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                   {displayedCategories.map((category, index) => (
-                    <Checkbox
-                      key={index}
-                      id={`checkbox-r-category-${category.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
-                      label={formatFacetLabel(category) + " (" + countItemsByProperty(items, 'category', category) + ")"}
-                      checked={selectedCategories.includes(category)}
-                      onChange={(_, data) => handleCategoryChange(category, data.checked)}
-                    />
+                    <li key={index} style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+                      <Checkbox
+                        id={`checkbox-r-category-${category.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
+                        label={formatFacetLabel(category) + " (" + countItemsByProperty(items, 'category', category) + ")"}
+                        checked={selectedCategories.includes(category)}
+                        onChange={(_, data) => handleCategoryChange(category, data.checked)}
+                      />
+                    </li>
                   ))}
-                </div>
+                </ul>
                 {categories.length > 10 && (
                   <Button appearance="secondary" onClick={() => setShowAllCategories(!showAllCategories)}>
                     {showAllCategories ? 'View Less' : 'View All'}
@@ -216,17 +242,18 @@ const FilterPane = ({
           <AccordionPanel>
             <div style={{ display: 'flex', flexDirection: 'column' }}>
               <div style={{ display: 'flex', flexDirection: 'column', rowGap: '10px' }}>
-                <div>
+                <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                   {displayedFocusAreas.map((focusArea, index) => (
-                    <Checkbox
-                      key={index}
-                      id={`checkbox-r-focus-area-${focusArea.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
-                      label={formatFacetLabel(focusArea) + " (" + countItemsByProperty(items, 'focusAreas', focusArea) + ")"}
-                      checked={selectedFocusAreas.includes(focusArea)}
-                      onChange={(_, data) => handleFocusAreaChange(focusArea, data.checked)}
-                    />
+                    <li key={index} style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+                      <Checkbox
+                        id={`checkbox-r-focus-area-${focusArea.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
+                        label={formatFacetLabel(focusArea) + " (" + countItemsByProperty(items, 'focusAreas', focusArea) + ")"}
+                        checked={selectedFocusAreas.includes(focusArea)}
+                        onChange={(_, data) => handleFocusAreaChange(focusArea, data.checked)}
+                      />
+                    </li>
                   ))}
-                </div>
+                </ul>
                 {focusAreas.length > 10 && (
                   <Button appearance="secondary" onClick={() => setShowAllFocusAreas(!showAllFocusAreas)}>
                     {showAllFocusAreas ? 'View Less' : 'View All'}
@@ -243,17 +270,18 @@ const FilterPane = ({
           <AccordionPanel>
             <div style={{ display: 'flex', flexDirection: 'column' }}>
               <div style={{ display: 'flex', flexDirection: 'column', rowGap: '10px' }}>
-                <div>
+                <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                   {displayedAudiences.map((audience, index) => (
-                    <Checkbox
-                      key={index}
-                      id={`checkbox-r-audience-${audience.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
-                      label={formatFacetLabel(audience) + " (" + countItemsByProperty(items, 'audiences', audience) + ")"}
-                      checked={selectedAudiences.includes(audience)}
-                      onChange={(_, data) => handleAudienceChange(audience, data.checked)}
-                    />
+                    <li key={index} style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+                      <Checkbox
+                        id={`checkbox-r-audience-${audience.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
+                        label={formatFacetLabel(audience) + " (" + countItemsByProperty(items, 'audiences', audience) + ")"}
+                        checked={selectedAudiences.includes(audience)}
+                        onChange={(_, data) => handleAudienceChange(audience, data.checked)}
+                      />
+                    </li>
                   ))}
-                </div>
+                </ul>
                 {audiences.length > 10 && (
                   <Button appearance="secondary" onClick={() => setShowAllAudiences(!showAllAudiences)}>
                     {showAllAudiences ? 'View Less' : 'View All'}
@@ -269,19 +297,47 @@ const FilterPane = ({
         <AccordionPanel>
             <div style={{ display: 'flex', flexDirection: 'column' }}>
               <div style={{ display: 'flex', flexDirection: 'column', rowGap: '10px' }}>
-                <div>
-                  {displayedTopics.map((topic, index) => (
-                    <Checkbox 
-                      key={index}
-                      id={`checkbox-r-topic-${topic.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
-                      label={topic + " (" + countItemsByProperty(items, 'topics', topic) + ")"}
-                      checked={selectedTopics.includes(topic)}
-                      onChange={(_, data) => handleTopicChange(topic, data.checked)}
+                {showAllTopics ? (
+                  <>
+                    <Input
+                      placeholder="Search topics…"
+                      value={topicSearch}
+                      onChange={(_, data) => setTopicSearch(data.value)}
+                      style={{ marginBottom: '8px', width: '100%' }}
                     />
-                  ))}
-                </div>
+                    <div style={{ maxHeight: '280px', overflowY: 'auto' }}>
+                      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                        {topics
+                          .filter(t => t.toLowerCase().includes(topicSearch.toLowerCase()))
+                          .map((topic, index) => (
+                            <li key={index} style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+                              <Checkbox 
+                                id={`checkbox-r-topic-${topic.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
+                                label={topic + " (" + countItemsByProperty(items, 'topics', topic) + ")"}
+                                checked={selectedTopics.includes(topic)}
+                                onChange={(_, data) => handleTopicChange(topic, data.checked)}
+                              />
+                            </li>
+                          ))}
+                      </ul>
+                    </div>
+                  </>
+                ) : (
+                  <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                    {displayedTopics.map((topic, index) => (
+                      <li key={index} style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+                        <Checkbox 
+                          id={`checkbox-r-topic-${topic.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
+                          label={topic + " (" + countItemsByProperty(items, 'topics', topic) + ")"}
+                          checked={selectedTopics.includes(topic)}
+                          onChange={(_, data) => handleTopicChange(topic, data.checked)}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                )}
                 {topics.length > 10 && (
-                  <Button appearance="secondary" onClick={() => setShowAllTopics(!showAllTopics)}>
+                  <Button appearance="secondary" onClick={() => { setShowAllTopics(!showAllTopics); if (showAllTopics) setTopicSearch(''); }}>
                     {showAllTopics ? 'View Less' : 'View All'}
                   </Button>
                 )}
@@ -294,17 +350,18 @@ const FilterPane = ({
         <AccordionPanel>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <div style={{ display: 'flex', flexDirection: 'column', rowGap: '10px' }}>
-              <div>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                 {displayedLanguages.map((language, index) => (
-                  <Checkbox 
-                    key={index}
-                    id={`checkbox-r-language-${language.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
-                    label={language + " (" + countItemsByProperty(items, 'languages', language) + ")"} 
-                    checked={selectedLanguages.includes(language)}
-                    onChange={(_, data) => handleLanguageChange(language, data.checked)}
-                  />
+                  <li key={index} style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+                    <Checkbox 
+                      id={`checkbox-r-language-${language.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
+                      label={language + " (" + countItemsByProperty(items, 'languages', language) + ")"} 
+                      checked={selectedLanguages.includes(language)}
+                      onChange={(_, data) => handleLanguageChange(language, data.checked)}
+                    />
+                  </li>
                 ))}
-              </div>
+              </ul>
               {languages.length > 10 && (
                 <Button appearance="secondary" onClick={() => setShowAllLanguages(!showAllLanguages)}>
                   {showAllLanguages ? 'View Less' : 'View All'}
@@ -319,17 +376,18 @@ const FilterPane = ({
         <AccordionPanel>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <div style={{ display: 'flex', flexDirection: 'column', rowGap: '10px' }}>
-              <div>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                 {displayedLicenses.map((license, index) => (
-                  <Checkbox 
-                    key={index}
-                    id={`checkbox-r-license-${license.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
-                    label={license + " (" + countItemsByProperty(items, 'license.name', license) + ")"} 
-                    checked={selectedLicenses.includes(license)}
-                    onChange={(_, data) => handleLicenseChange(license, data.checked)}
-                  />
+                  <li key={index} style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+                    <Checkbox 
+                      id={`checkbox-r-license-${license.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
+                      label={license + " (" + countItemsByProperty(items, 'license.name', license) + ")"} 
+                      checked={selectedLicenses.includes(license)}
+                      onChange={(_, data) => handleLicenseChange(license, data.checked)}
+                    />
+                  </li>
                 ))}
-              </div>
+              </ul>
               {licenses.length > 10 && (
                 <Button appearance="secondary" onClick={() => setShowAllLicenses(!showAllLicenses)}>
                   {showAllLicenses ? 'View Less' : 'View All'}
@@ -344,19 +402,47 @@ const FilterPane = ({
         <AccordionPanel>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <div style={{ display: 'flex', flexDirection: 'column', rowGap: '10px' }}>
-              <div>
-                {displayedOwners.map((owner, index) => (
-                  <Checkbox 
-                    key={index}
-                    id={`checkbox-r-owner-${owner.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
-                    label={owner + " (" + countItemsByProperty(items, 'owner.login', owner) + ")"} 
-                    checked={selectedOwners.includes(owner)}
-                    onChange={(_, data) => handleOwnerChange(owner, data.checked)}
+              {showAllOwners ? (
+                <>
+                  <Input
+                    placeholder="Search owners…"
+                    value={ownerSearch}
+                    onChange={(_, data) => setOwnerSearch(data.value)}
+                    style={{ marginBottom: '8px', width: '100%' }}
                   />
-                ))}
-              </div>
+                  <div style={{ maxHeight: '280px', overflowY: 'auto' }}>
+                    <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                      {owners
+                        .filter(o => o.toLowerCase().includes(ownerSearch.toLowerCase()))
+                        .map((owner, index) => (
+                          <li key={index} style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+                            <Checkbox 
+                              id={`checkbox-r-owner-${owner.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
+                              label={owner + " (" + countItemsByProperty(items, 'owner.login', owner) + ")"} 
+                              checked={selectedOwners.includes(owner)}
+                              onChange={(_, data) => handleOwnerChange(owner, data.checked)}
+                            />
+                          </li>
+                        ))}
+                    </ul>
+                  </div>
+                </>
+              ) : (
+                <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                  {displayedOwners.map((owner, index) => (
+                    <li key={index} style={{ minHeight: '44px', display: 'flex', alignItems: 'center' }}>
+                      <Checkbox 
+                        id={`checkbox-r-owner-${owner.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}
+                        label={owner + " (" + countItemsByProperty(items, 'owner.login', owner) + ")"} 
+                        checked={selectedOwners.includes(owner)}
+                        onChange={(_, data) => handleOwnerChange(owner, data.checked)}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              )}
               {owners.length > 10 && (
-                <Button appearance="secondary" onClick={() => setShowAllOwners(!showAllOwners)}>
+                <Button appearance="secondary" onClick={() => { setShowAllOwners(!showAllOwners); if (showAllOwners) setOwnerSearch(''); }}>
                   {showAllOwners ? 'View Less' : 'View All'}
                 </Button>
               )}

--- a/Website/src/components/Gallery/index.tsx
+++ b/Website/src/components/Gallery/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { format } from 'date-fns';
 
 import {
@@ -56,6 +56,7 @@ type GalleryProps = {
     onAudiencesChange: (values: string[]) => void;
     onTopicsChange: (values: string[]) => void;
     onSortByChange: (sortBy: string) => void;
+    onClearAllFilters?: () => void;
 }
 
 const Gallery = ({
@@ -76,9 +77,11 @@ const Gallery = ({
     onAudiencesChange,
     onTopicsChange,
     onSortByChange,
+    onClearAllFilters,
 }: GalleryProps) => {
     const [selectedItem, setSelectedItem] = useState<Repository | null>(null);
     const [hideDialog, setHideDialog] = useState(true);
+    const [page, setPage] = useState(1);
     const comboId = useId("combo-orderby");
     const options = [
         { key: 'starsAsc', text: 'Stars (Ascending)' },
@@ -104,6 +107,13 @@ const Gallery = ({
         selectedFocusAreas,
         selectedAudiences,
     });
+
+    const filterKey = JSON.stringify({
+        hasGoodFirstIssueChecked, hasHelpWantedIssueChecked, hasCodeOfConductChecked,
+        selectedTopics, selectedLanguages, selectedLicenses, selectedOwners,
+        selectedCategories, selectedFocusAreas, selectedAudiences,
+    });
+    useEffect(() => { setPage(1); }, [filterKey]);
 
     const openDialog = (item) => {
         setSelectedItem(item);
@@ -200,6 +210,11 @@ const Gallery = ({
 
     const sortedItems = sortItems(filteredItems, selectedOptions);
     const featuredItems = getFeaturedSpotlightItems(sortedItems);
+
+    const PAGE_SIZE = 30;
+    const totalPages = Math.max(1, Math.ceil(sortedItems.length / PAGE_SIZE));
+    const clampedPage = Math.min(page, totalPages);
+    const pagedItems = sortedItems.slice((clampedPage - 1) * PAGE_SIZE, clampedPage * PAGE_SIZE);
     const renderRelaunchBadges = (item: Repository, testIdPrefix: string) => {
         const badges = getRelaunchBadgeEntries(item);
         if (badges.length === 0) {
@@ -247,9 +262,9 @@ const Gallery = ({
     return (
         <div style={{ width: '100%' }}>
             <div className={styles.galleryHeader}>
-                <Text id="repositoryCount" size={400}>{`${filteredItems.length} repositories found`}</Text>
+                <Text id="repositoryCount" size={400}>{`${filteredItems.length} ${filteredItems.length === 1 ? 'repository' : 'repositories'} found`}{totalPages > 1 ? ` (page ${clampedPage} of ${totalPages})` : ''}</Text>
                 <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <Text id={comboId} style={{ marginRight: '10px' }} size={400}>Order By</Text>
+                    <Text id={comboId} style={{ marginRight: '10px' }} size={400}>Sort by</Text>
                     <Combobox
                         id="orderByCombobox" // Add an ID for easier UI testing
                         aria-labelledby={comboId}
@@ -309,143 +324,207 @@ const Gallery = ({
                     </div>
                 </section>
             )}
-            <div className={styles.gallery}>
-                {sortedItems.map((item, index) => (
-                    <Card className={styles.galleryItem} data-testid="repository-card" key={index}>
-                        {["microsoft", "azure"].includes(item.owner.login.toLowerCase()) ? (
-                            <CardHeader
-                                header={
-                                    <div className={styles.cardHeader}>
-                                        <div className={styles.cardHeaderLeftContent}>
-                                            <img src="/PowerPlatform-OpenSource-Hub/img/Microsoft.svg" alt='Microsoft logo' width="16px" height="16px" style={{ paddingRight: '5px' }} />
-                                            <Body1>
-                                                Microsoft Authored
-                                            </Body1>
-                                        </div>
-                                        <div className={styles.cardHeaderRightContent}>
-                                            {isActive(item.updatedAt) && 
-                                                <Tooltip content={`Last update on: ${format(new Date(item.updatedAt), 'yyyy-MM-dd')}`} relationship={'label'}>
-                                                    <Badge data-testid="active-badge" appearance="outline" style={{ marginRight: '5px' }}>🔥 Active</Badge>
-                                                </Tooltip>
-                                            }
-                                            <Badge data-testid="stars-badge" appearance="filled" color="warning" icon={<Star16Filled />} key={index}>{item.stargazerCount}</Badge>
-                                        </div>
-                                    </div>
-                                }
-                            />
-                        ) : (
-                            <CardHeader
-                                header={
-                                    <div className={styles.cardHeader}>
-                                        <div className={styles.cardHeaderLeftContent}>
-                                            <img src="/PowerPlatform-OpenSource-Hub/img/Community.svg" alt='Community icon' width="16px" height="16px" style={{ paddingRight: '5px' }} />
-                                            <Body1>
-                                                Community Authored
-                                            </Body1>
-                                        </div>
-                                        <div className={styles.cardHeaderRightContent}>
-                                            {isActive(item.updatedAt) && 
-                                                <Tooltip content={`Last update on: ${format(new Date(item.updatedAt), 'yyyy-MM-dd')}`} relationship={'label'}>
-                                                    <Badge data-testid="active-badge" appearance="outline" style={{ marginRight: '5px' }}>🔥 Active</Badge>
-                                                </Tooltip>
-                                            }
-                                            <Badge data-testid="stars-badge" appearance="filled" color="warning" icon={<Star16Filled />} key={index}>{item.stargazerCount}</Badge>
-                                        </div>
-                                    </div>
-                                }
-                            />
-                        )}
-
-                        <CardPreview className={styles.cardBreakLine} />
-
-                        <Subtitle1 data-testid="repository-full-name" style={{ maxHeight: '60px', height: '60px', fontSize: '16px' }}>
-                            {item.fullName}
-                        </Subtitle1>
-
-                        <Text data-testid="repository-description">
-                            {getRepositoryDescription(item).length > 150 ?
-                                <p>
-                                    {getRepositoryDescription(item).substring(0, 150) + '... '}
-                                </p>
-                                :
-                                getRepositoryDescription(item)
-                            }
-                        </Text>
-
-                        {renderRelaunchBadges(item, 'card')}
-
-                        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-                            {item.topics.slice(0, 5).map((topic, index) => (
-                                renderTopicBadge(topic, `${topic}-${index}`, 'topic-badge')
-                            ))}
-                        </div>
-
-                        <CardFooter className={styles.cardFooter}>
-                            <Button data-testid="open-in-github-button" data-repository-url={item.url} icon={<OpenRegular fontSize={16} />} onClick={() => openInGitHub(item.url)}>Open in GitHub</Button>
-                            <Button data-testid="see-more-button" icon={<ArrowExpand16Regular fontSize={16} />} onClick={() => openDialog(item)}>See more...</Button>
-                        </CardFooter>
-                    </Card>
-                ))}
-                <Dialog
-                    open={!hideDialog}
-                    onOpenChange={(_, data) => setHideDialog(!data.open)}
-                >
-                    <DialogSurface data-testid="repository-dialog">
-                        <DialogTitle data-testid="dialog-title" className={styles.dialogTitle}>
-                            {selectedItem?.fullName}
-                            <div style={{ display: 'flex', gap: '5px', flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
-                                {isActive(selectedItem?.updatedAt) && 
-                                    <Tooltip content={`Last update on: ${format(new Date(selectedItem?.updatedAt), 'yyyy-MM-dd')}`} relationship={'label'}>
-                                        <Badge data-testid="dialog-active-badge" appearance="outline" style={{ marginRight: '5px' }}>🔥 Active</Badge>
-                                    </Tooltip>
-                                }
-                                <Badge data-testid="dialog-stars-badge" appearance="filled" color="warning" icon={<Star16Filled />}>{selectedItem?.stargazerCount}</Badge>
-                                <Badge data-testid="dialog-watchers-badge" appearance="outline" icon={<Eye16Filled />}>{selectedItem?.watchers.totalCount}</Badge>
-                                <DialogTrigger action="close">
-                                    <Button
-                                        appearance="subtle"
-                                        aria-label="close"
-                                        icon={<Dismiss24Regular />}
-                                        onClick={closeDialog}
+            {filteredItems.length === 0 ? (
+                <div style={{ textAlign: 'center', padding: '60px 20px', width: '100%' }}>
+                    <Text size={500} style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>No repositories found</Text>
+                    <Text size={300} style={{ display: 'block', marginBottom: '20px', color: 'var(--ifm-color-secondary-darkest)' }}>
+                        Try adjusting your search or filters.
+                    </Text>
+                    {onClearAllFilters && (
+                        <Button appearance="primary" onClick={onClearAllFilters}>Clear all filters</Button>
+                    )}
+                </div>
+            ) : (
+                <>
+                    <div className={styles.gallery}>
+                        {pagedItems.map((item) => (
+                            <Card role="article" className={styles.galleryItem} data-testid="repository-card" key={item.repositoryId ?? item.fullName}>
+                                {["microsoft", "azure"].includes(item.owner.login.toLowerCase()) ? (
+                                    <CardHeader
+                                        header={
+                                            <div className={styles.cardHeader}>
+                                                <div className={styles.cardHeaderLeftContent}>
+                                                    <img src="/PowerPlatform-OpenSource-Hub/img/Microsoft.svg" alt='Microsoft logo' width="16px" height="16px" style={{ paddingRight: '5px' }} />
+                                                    <Body1>
+                                                        Microsoft Authored
+                                                    </Body1>
+                                                </div>
+                                                <div className={styles.cardHeaderRightContent}>
+                                                    {isActive(item.updatedAt) && 
+                                                        <Tooltip content={`Last update on: ${format(new Date(item.updatedAt), 'yyyy-MM-dd')}`} relationship={'label'}>
+                                                            <Badge data-testid="active-badge" appearance="outline" style={{ marginRight: '5px' }}>🔥 Active</Badge>
+                                                        </Tooltip>
+                                                    }
+                                                    <Badge data-testid="stars-badge" appearance="filled" color="warning" icon={<Star16Filled />}>{item.stargazerCount}</Badge>
+                                                </div>
+                                            </div>
+                                        }
                                     />
-                                </DialogTrigger>
-                            </div>
-                        </DialogTitle>
-                        <DialogContent style={{ marginBottom: '16px', marginTop: '16px' }}>
-                            <DialogBody>
-                                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                                    <Text data-testid="dialog-description">
-                                        {getRepositoryDescription(selectedItem)}
-                                    </Text>
-                                    {selectedItem && renderRelaunchBadges(selectedItem, 'dialog')}
-                                    <div style={{ marginTop: '10px', display: 'flex', flexWrap: 'wrap', flexDirection: 'column' }}>
-                                        {selectedItem?.license?.name && (
-                                            <Badge data-testid="dialog-license-badge" appearance="tint" style={{ marginBottom: '4px' }}>License: {selectedItem?.license?.name}</Badge>
-                                        )}
-                                        <Badge data-testid="dialog-good-first-issues-badge" appearance="tint" style={{ marginBottom: '4px' }}>Good 1st Issues: {selectedItem?.openedGoodFirstIssues}</Badge>
-                                        <Badge data-testid="dialog-help-wanted-issues-badge" appearance="tint" style={{ marginBottom: '4px' }}>Help Wanted Issues: {selectedItem?.openedHelpWantedIssues}</Badge>
-                                        {selectedItem?.language && (
-                                            <Badge data-testid="dialog-main-language-badge" appearance="tint" style={{ marginBottom: '4px' }}>Language: {selectedItem?.language}</Badge>
-                                        )}
-                                        {selectedItem?.latestRelease && (
-                                            <Badge data-testid="dialog-latest-release-badge" appearance="tint" style={{ marginBottom: '4px' }}>Latest Release: {selectedItem?.latestRelease.tagName} ({format(new Date(selectedItem?.latestRelease.publishedAt), 'yyyy-MM-dd')})</Badge>
-                                        )}
-                                    </div>
-                                </div>
+                                ) : (
+                                    <CardHeader
+                                        header={
+                                            <div className={styles.cardHeader}>
+                                                <div className={styles.cardHeaderLeftContent}>
+                                                    <img src="/PowerPlatform-OpenSource-Hub/img/Community.svg" alt='Community icon' width="16px" height="16px" style={{ paddingRight: '5px' }} />
+                                                    <Body1>
+                                                        Community Authored
+                                                    </Body1>
+                                                </div>
+                                                <div className={styles.cardHeaderRightContent}>
+                                                    {isActive(item.updatedAt) && 
+                                                        <Tooltip content={`Last update on: ${format(new Date(item.updatedAt), 'yyyy-MM-dd')}`} relationship={'label'}>
+                                                            <Badge data-testid="active-badge" appearance="outline" style={{ marginRight: '5px' }}>🔥 Active</Badge>
+                                                        </Tooltip>
+                                                    }
+                                                    <Badge data-testid="stars-badge" appearance="filled" color="warning" icon={<Star16Filled />}>{item.stargazerCount}</Badge>
+                                                </div>
+                                            </div>
+                                        }
+                                    />
+                                )}
+
+                                <CardPreview className={styles.cardBreakLine} />
+
+                                <a href={item.url} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none', color: 'inherit' }}>
+                                    <Subtitle1 data-testid="repository-full-name" style={{ maxHeight: '60px', height: '60px', fontSize: '16px' }}>
+                                        {item.fullName}
+                                    </Subtitle1>
+                                </a>
+
+                                <Text data-testid="repository-description">
+                                    {getRepositoryDescription(item).length > 150 ?
+                                        <p>
+                                            {getRepositoryDescription(item).substring(0, 150) + '... '}
+                                        </p>
+                                        :
+                                        getRepositoryDescription(item)
+                                    }
+                                </Text>
+
+                                {renderRelaunchBadges(item, 'card')}
+
                                 <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-                                    {selectedItem?.topics.map((topic, index) => (
-                                        renderTopicBadge(topic, `dialog-${topic}-${index}`, 'dialog-topic-badge', '1px')
+                                    {item.topics.slice(0, 4).map((topic, index) => (
+                                        renderTopicBadge(topic, `${topic}-${index}`, 'topic-badge')
                                     ))}
+                                    {item.topics.length > 4 && (
+                                        <Badge appearance="ghost" style={{ marginRight: '2px', marginBottom: '2px', fontSize: '11px', cursor: 'default' }}>
+                                            +{item.topics.length - 4} more
+                                        </Badge>
+                                    )}
                                 </div>
-                            </DialogBody>
-                        </DialogContent>
-                        <DialogActions>
-                            <Button data-testid="dialog-close-button" appearance="secondary" onClick={closeDialog}>Close</Button>
-                            <Button data-testid="dialog-open-in-github-button" data-repository-url={selectedItem?.url} appearance="primary" onClick={() => openInGitHub(selectedItem?.url)}>Open in GitHub</Button>
-                        </DialogActions>
-                    </DialogSurface>
-                </Dialog>
-            </div>
+
+                                <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', padding: '0 4px 4px' }}>
+                                    {item.language && (
+                                        <Badge appearance="tint" style={{ fontSize: '11px' }}>{item.language}</Badge>
+                                    )}
+                                    <Badge appearance="tint" style={{ fontSize: '11px' }}>
+                                        Updated {format(new Date(item.updatedAt), 'MMM yyyy')}
+                                    </Badge>
+                                </div>
+
+                                <CardFooter className={styles.cardFooter}>
+                                    <Button data-testid="open-in-github-button" data-repository-url={item.url} icon={<OpenRegular fontSize={16} />} onClick={() => openInGitHub(item.url)}>Open in GitHub</Button>
+                                    <Button data-testid="see-more-button" icon={<ArrowExpand16Regular fontSize={16} />} onClick={() => openDialog(item)}>See more...</Button>
+                                </CardFooter>
+                            </Card>
+                        ))}
+                    </div>
+                    {totalPages > 1 && (
+                        <nav aria-label="Pagination" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '4px', margin: '16px 0', flexWrap: 'wrap' }}>
+                            <Button
+                                appearance="secondary"
+                                disabled={clampedPage === 1}
+                                onClick={() => setPage(clampedPage - 1)}
+                                style={{ minHeight: '44px' }}
+                            >
+                                Previous
+                            </Button>
+                            {(() => {
+                                const start = Math.max(1, clampedPage - 2);
+                                const end = Math.min(totalPages, start + 4);
+                                return Array.from({ length: end - start + 1 }, (_, i) => start + i).map(p => (
+                                    <Button
+                                        key={p}
+                                        appearance={p === clampedPage ? 'primary' : 'subtle'}
+                                        onClick={() => setPage(p)}
+                                        style={{ minHeight: '44px', minWidth: '44px' }}
+                                    >
+                                        {p}
+                                    </Button>
+                                ));
+                            })()}
+                            <Button
+                                appearance="secondary"
+                                disabled={clampedPage === totalPages}
+                                onClick={() => setPage(clampedPage + 1)}
+                                style={{ minHeight: '44px' }}
+                            >
+                                Next
+                            </Button>
+                        </nav>
+                    )}
+                </>
+            )}
+            <Dialog
+                open={!hideDialog}
+                onOpenChange={(_, data) => setHideDialog(!data.open)}
+            >
+                <DialogSurface data-testid="repository-dialog">
+                    <DialogTitle data-testid="dialog-title" className={styles.dialogTitle}>
+                        {selectedItem?.fullName}
+                        <div style={{ display: 'flex', gap: '5px', flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
+                            {isActive(selectedItem?.updatedAt) && 
+                                <Tooltip content={`Last update on: ${format(new Date(selectedItem?.updatedAt), 'yyyy-MM-dd')}`} relationship={'label'}>
+                                    <Badge data-testid="dialog-active-badge" appearance="outline" style={{ marginRight: '5px' }}>🔥 Active</Badge>
+                                </Tooltip>
+                            }
+                            <Badge data-testid="dialog-stars-badge" appearance="filled" color="warning" icon={<Star16Filled />}>{selectedItem?.stargazerCount}</Badge>
+                            <Badge data-testid="dialog-watchers-badge" appearance="outline" icon={<Eye16Filled />}>{selectedItem?.watchers.totalCount}</Badge>
+                            <DialogTrigger action="close">
+                                <Button
+                                    appearance="subtle"
+                                    aria-label="close"
+                                    icon={<Dismiss24Regular />}
+                                    onClick={closeDialog}
+                                />
+                            </DialogTrigger>
+                        </div>
+                    </DialogTitle>
+                    <DialogContent style={{ marginBottom: '16px', marginTop: '16px' }}>
+                        <DialogBody>
+                            <div style={{ display: 'flex', flexDirection: 'column' }}>
+                                <Text data-testid="dialog-description">
+                                    {getRepositoryDescription(selectedItem)}
+                                </Text>
+                                {selectedItem && renderRelaunchBadges(selectedItem, 'dialog')}
+                                <div style={{ marginTop: '10px', display: 'flex', flexWrap: 'wrap', flexDirection: 'column' }}>
+                                    {selectedItem?.license?.name && (
+                                        <Badge data-testid="dialog-license-badge" appearance="tint" style={{ marginBottom: '4px' }}>License: {selectedItem?.license?.name}</Badge>
+                                    )}
+                                    <Badge data-testid="dialog-good-first-issues-badge" appearance="tint" style={{ marginBottom: '4px' }}>Good 1st Issues: {selectedItem?.openedGoodFirstIssues}</Badge>
+                                    <Badge data-testid="dialog-help-wanted-issues-badge" appearance="tint" style={{ marginBottom: '4px' }}>Help Wanted Issues: {selectedItem?.openedHelpWantedIssues}</Badge>
+                                    {selectedItem?.language && (
+                                        <Badge data-testid="dialog-main-language-badge" appearance="tint" style={{ marginBottom: '4px' }}>Language: {selectedItem?.language}</Badge>
+                                    )}
+                                    {selectedItem?.latestRelease && (
+                                        <Badge data-testid="dialog-latest-release-badge" appearance="tint" style={{ marginBottom: '4px' }}>Latest Release: {selectedItem?.latestRelease.tagName} ({format(new Date(selectedItem?.latestRelease.publishedAt), 'yyyy-MM-dd')})</Badge>
+                                    )}
+                                </div>
+                            </div>
+                            <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+                                {selectedItem?.topics.map((topic, index) => (
+                                    renderTopicBadge(topic, `dialog-${topic}-${index}`, 'dialog-topic-badge', '1px')
+                                ))}
+                            </div>
+                        </DialogBody>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button data-testid="dialog-close-button" appearance="secondary" onClick={closeDialog}>Close</Button>
+                        <Button data-testid="dialog-open-in-github-button" data-repository-url={selectedItem?.url} appearance="primary" onClick={() => openInGitHub(selectedItem?.url)}>Open in GitHub</Button>
+                    </DialogActions>
+                </DialogSurface>
+            </Dialog>
         </div>
     );
 };

--- a/Website/src/components/Gallery/index.tsx
+++ b/Website/src/components/Gallery/index.tsx
@@ -447,12 +447,14 @@ const Gallery = ({
                                     <Button
                                         key={p}
                                         appearance={p === clampedPage ? 'primary' : 'subtle'}
-                                        onClick={() => setPage(p)}
-                                        style={{ minHeight: '44px', minWidth: '44px' }}
-                                    >
-                                        {p}
-                                    </Button>
-                                ));
+                                                        aria-label={`Go to page ${p}`}
+                                                        aria-current={p === clampedPage ? 'page' : undefined}
+                                                        onClick={() => setPage(p)}
+                                                        style={{ minHeight: '44px', minWidth: '44px' }}
+                                                    >
+                                                        {p}
+                                                    </Button>
+                                                ));
                             })()}
                             <Button
                                 appearance="secondary"

--- a/Website/src/components/Gallery/styles.module.css
+++ b/Website/src/components/Gallery/styles.module.css
@@ -18,6 +18,13 @@
     grid-gap: 10px; /* adjust as needed */
 }
 
+@media (max-width: 960px) {
+    .gallery {
+        grid-template-columns: repeat(auto-fit, minmax(min(350px, 100%), 1fr));
+        padding: 4px;
+    }
+}
+
 /* Styling for the gallery item */
 .galleryItem {
     display: flex; /* Use flexbox for layout */
@@ -26,6 +33,17 @@
     max-width: 450px; /* Set max width */
     max-height: 400px; /* Set max height */
     margin: 10px; /* Add margin all around */
+    transition: box-shadow 0.15s ease, transform 0.1s ease;
+    cursor: pointer;
+}
+
+.galleryItem:hover {
+    box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+    transform: translateY(-2px);
+}
+
+[data-theme="dark"] .galleryItem:hover {
+    box-shadow: 0 4px 16px rgba(0,0,0,0.4);
 }
 
 /* Styling for the gallery item in dark theme */
@@ -49,6 +67,10 @@
     font-size: 13px; /* Set font size */
     height: 60%; /* Set height to 60% of the parent container */
     padding: 20px; /* Add padding all around */
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
 }
 
 /* Styling for the gallery item stars count */

--- a/Website/src/css/custom.css
+++ b/Website/src/css/custom.css
@@ -15,6 +15,7 @@
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --ifm-navbar-mobile-breakpoint: 960px;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/Website/src/pages/index.module.css
+++ b/Website/src/pages/index.module.css
@@ -15,8 +15,8 @@
 
 /* Styling for the hero banner in dark theme */
 [data-theme="dark"] .heroBanner {
-  /* Darker gradient background for dark mode */
-  background: linear-gradient(90deg, rgba(44,142,75,1.2) 0%, rgba(185,228,247,1.2) 35%, rgba(10,110,159,1.2) 100%);
+  /* Darker gradient for dark mode — deep green to deep navy */
+  background: linear-gradient(90deg, rgba(12, 50, 28, 1) 0%, rgba(8, 35, 55, 1) 50%, rgba(5, 30, 60, 1) 100%);
 }
 
 /* Media query for screens with max width of 996px */
@@ -54,9 +54,10 @@
   align-items: flex-start; /* Change this line */
   padding: 30px;
   position: relative;
+  overflow-x: hidden;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 960px) {
   .filterPaneAndGallery {
     flex-direction: column;
     align-items: stretch;
@@ -66,4 +67,25 @@
 /* Styling for the filter pane and gallery in dark theme */
 [data-theme="dark"] .filterPaneAndGallery {
   background-color: #1f1f1f; /* Dark background color */
+}
+
+/* Hero title — solid accessible color per theme */
+.heroTitle {
+  color: #1b1b1b !important;
+  background: none !important;
+  -webkit-background-clip: unset !important;
+  -webkit-text-fill-color: unset !important;
+}
+
+[data-theme="dark"] .heroTitle {
+  color: #f5f5f5 !important;
+}
+
+/* Hero subtitle — accessible color per theme */
+.heroSubtitle {
+  color: #3b3b3b !important;
+}
+
+[data-theme="dark"] .heroSubtitle {
+  color: #e8e8e8 !important;
 }

--- a/Website/src/pages/index.tsx
+++ b/Website/src/pages/index.tsx
@@ -35,18 +35,11 @@ import FilterPane from '../components/FilterPane';
 const App = () => {
   const { siteConfig } = useDocusaurusContext();
   const { colorMode } = useColorMode();
-  const [loading, setLoading] = useState(true);
   const [isMobile, setIsMobile] = useState(false);
   const [isFilterPaneOpen, setIsFilterPaneOpen] = useState(false);
   const [isFilterStateInitialized, setIsFilterStateInitialized] = useState(false);
   const [filterState, setFilterState] = useState<UrlFilterState>(defaultUrlFilterState);
   const historyWriteModeRef = useRef<'replace' | 'push'>('replace');
-
-  useEffect(() => {
-    setTimeout(() => {
-      setLoading(false);
-    }, 500);
-  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -109,6 +102,23 @@ const App = () => {
     setFilterState((previous) => updater(previous));
   };
 
+  const handleClearAllFilters = () => setFilterStateWithHistory(() => defaultUrlFilterState, 'push');
+
+  const hasAnyActiveFilters = useMemo(
+    () =>
+      filterState.hasGoodFirstIssueChecked ||
+      filterState.hasHelpWantedIssueChecked ||
+      filterState.hasCodeOfConductChecked ||
+      filterState.selectedTopics.length > 0 ||
+      filterState.selectedLanguages.length > 0 ||
+      filterState.selectedLicenses.length > 0 ||
+      filterState.selectedOwners.length > 0 ||
+      filterState.selectedCategories.length > 0 ||
+      filterState.selectedFocusAreas.length > 0 ||
+      filterState.selectedAudiences.length > 0,
+    [filterState],
+  );
+
   const items = useMemo(
     () => filterItemsBasedOnSearchInput(data as Repository[], filterState.searchText),
     [filterState.searchText],
@@ -138,21 +148,19 @@ const App = () => {
       onCategoriesChange={(value) => setFilterStateWithHistory((previous) => ({ ...previous, selectedCategories: value }))}
       onFocusAreasChange={(value) => setFilterStateWithHistory((previous) => ({ ...previous, selectedFocusAreas: value }))}
       onAudiencesChange={(value) => setFilterStateWithHistory((previous) => ({ ...previous, selectedAudiences: value }))}
+      onClearAllFilters={handleClearAllFilters}
+      hasAnyActiveFilters={hasAnyActiveFilters}
     />
   );
 
-  return !loading ? (
+  return isFilterStateInitialized ? (
     <FluentProvider theme={colorMode === 'dark' ? webDarkTheme : webLightTheme}>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column' }}>
-          <Heading as="h2" className="hero__title" style={{
-            background: 'linear-gradient(90deg, rgba(10,110,159,1.2) 0%, rgba(10,110,159,1.2) 0%, rgba(44,142,75,1.2) 100%)',
-            WebkitBackgroundClip: 'text',
-            WebkitTextFillColor: 'transparent',
-          }}>
+          <Heading as="h1" className={clsx('hero__title', styles.heroTitle)}>
             {siteConfig.title}
           </Heading>
-          <p className="hero__subtitle" style={{ color: '#242424', padding: '10px 0 20px 0' }}>
+          <p className={clsx('hero__subtitle', styles.heroSubtitle)} style={{ padding: '10px 0 20px 0' }}>
             {siteConfig.tagline}
           </p>
           <Input
@@ -160,6 +168,7 @@ const App = () => {
             type="search"
             size="large"
             placeholder="Search for a Power Platform GitHub repository..."
+            aria-label="Search repositories"
             value={filterState.searchText}
             onChange={(_, data) => setFilterStateWithHistory((previous) => ({ ...previous, searchText: data.value }), 'replace')}
             style={{ width: '100%', maxWidth: '740px' }}
@@ -175,11 +184,20 @@ const App = () => {
                   id="openFiltersButton"
                   icon={<Filter16Regular />}
                   onClick={() => setIsFilterPaneOpen(true)}
+                  style={{ minHeight: '44px' }}
                 >
                   Filters
                 </Button>
               </div>
-              <Dialog open={isFilterPaneOpen} onOpenChange={(_, data) => setIsFilterPaneOpen(data.open)}>
+              <Dialog
+                open={isFilterPaneOpen}
+                onOpenChange={(_, data) => {
+                  setIsFilterPaneOpen(data.open);
+                  if (!data.open) {
+                    setTimeout(() => document.getElementById('openFiltersButton')?.focus(), 50);
+                  }
+                }}
+              >
                 <DialogSurface>
                   <DialogBody>
                     <DialogTitle>Filters</DialogTitle>
@@ -209,6 +227,7 @@ const App = () => {
             onAudiencesChange={(value) => setFilterStateWithHistory((previous) => ({ ...previous, selectedAudiences: value }))}
             onTopicsChange={(value) => setFilterStateWithHistory((previous) => ({ ...previous, selectedTopics: value }))}
             onSortByChange={(value) => setFilterStateWithHistory((previous) => ({ ...previous, sortBy: value }))}
+            onClearAllFilters={handleClearAllFilters}
           />
         </div>
       </main>
@@ -220,7 +239,7 @@ export default function HomePage(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
 
   return (
-    <Layout title={`${siteConfig.title}`} description="Power Platform Open-Source Hub">
+    <Layout title={`${siteConfig.title}`} description="Discover 200+ open-source projects for Microsoft Power Platform and Copilot Studio — searchable, filterable, and community-driven.">
       <App />
     </Layout>
   );

--- a/Website/src/pages/index.tsx
+++ b/Website/src/pages/index.tsx
@@ -106,6 +106,7 @@ const App = () => {
 
   const hasAnyActiveFilters = useMemo(
     () =>
+      filterState.searchText.length > 0 ||
       filterState.hasGoodFirstIssueChecked ||
       filterState.hasHelpWantedIssueChecked ||
       filterState.hasCodeOfConductChecked ||

--- a/Website/tests/user_interface/tests/search-filter-pane-gallery-of-repositories.spec.ts
+++ b/Website/tests/user_interface/tests/search-filter-pane-gallery-of-repositories.spec.ts
@@ -120,21 +120,21 @@ test('Validate the count of repositories found when I enter a search term', asyn
 // Validate the filters default presentation
 // - all checkboxes are unchecked
 // - the list of the available sections is as expected (the order is important)
-// - only the "Contribution Opportunities" section is expanded
-// - the "Contribution Opportunities" section contains the expected checkboxes
+// - only the "Repository Signals" section is expanded
+// - the "Repository Signals" section contains the expected checkboxes
 test('Validate the filter pane default presentation', async ({ page }) => {
   await page.goto('/');
 
   // Array of the expected sections (the order is important)
   const expectedSections = [
-    'Contribution Opportunities',
+    'Repository Signals',
     'Topics',
     'Languages',
     'Licenses',
     'Owners'
   ];
 
-  // Array of the expected checkboxes for the "Contribution Opportunities" section
+  // Array of the expected checkboxes for the "Repository Signals" section
   const expectedContributionOpportunitiesCheckboxes = [
     'Has good first issue',
     'Has help wanted issue',
@@ -160,7 +160,7 @@ test('Validate the filter pane default presentation', async ({ page }) => {
   }));
   expect(sectionNames).toEqual(expectedSections);
 
-  // Validate that only the "Contribution Opportunities" section is expanded
+  // Validate that only the "Repository Signals" section is expanded
   // The button element in each section has a "aria-expanded" attribute allowing to know if the section is expanded or not
   let expandedSections = [];
   let nonExpandedSections = [];
@@ -183,13 +183,13 @@ test('Validate the filter pane default presentation', async ({ page }) => {
   }));
   expect(nonExpandedSectionNames).toEqual(expectedSections.slice(1));
 
-  // Validate that the "Contribution Opportunities" section contains the expected checkboxes
-  // The checkboxes to validate are under the div element with "fui-AccordionItem" class where there is a button with inner text equal to "Contribution Opportunities"
+  // Validate that the "Repository Signals" section contains the expected checkboxes
+  // The checkboxes to validate are under the div element with "fui-AccordionItem" class where there is a button with inner text equal to "Repository Signals"
   // The labels associated to the checboxes are label elements with a for attribute value like "checkbox-r..."
-  const contributionOpportunitiesSection = page.locator('.fui-AccordionItem').filter({
-    has: page.getByRole('button', { name: 'Contribution Opportunities' }),
+  const repositorySignalsSection = page.locator('.fui-AccordionItem').filter({
+    has: page.getByRole('button', { name: 'Repository Signals' }),
   });
-  const contributionOpportunitiesCheckboxesNames = (await contributionOpportunitiesSection.locator('label[for^="checkbox-r"]').allInnerTexts())
+  const contributionOpportunitiesCheckboxesNames = (await repositorySignalsSection.locator('label[for^="checkbox-r"]').allInnerTexts())
     .map((checkboxText) => checkboxText.split(' (')[0]);
   expect(contributionOpportunitiesCheckboxesNames).toEqual(expectedContributionOpportunitiesCheckboxes);
 });
@@ -287,7 +287,7 @@ test('Validate the visual behavior of a checkbox', async ({ page }) => {
   }
 });
 
-// Validate that for all sections with a dynamic list of checkboxes (do not consider "Contribution Opportunities") in the filter pane,
+// Validate that for all sections with a dynamic list of checkboxes (do not consider "Repository Signals") in the filter pane,
 // - there are no more than 10 checkboxes presented
 // - the checboxes are presented in descending order based on the count of repositories found
 // - if there are more than 10 checkboxes available, there is a "View All" button at the end of the list
@@ -296,8 +296,8 @@ test('Validate the presentation of the checkboxes in the sections of the filter 
 
   // Get all the sections in the filter pane
   const sections = (await getAllSections(page))
-    .filter((section) => section.headerText !== 'Contribution Opportunities')
-    .map((section) => section.section); // Exclude the "Contribution Opportunities" section because it has a static list of checkboxes
+    .filter((section) => section.headerText !== 'Repository Signals')
+    .map((section) => section.section); // Exclude the "Repository Signals" section because it has a static list of checkboxes
 
   // Validate that for all sections in the filter pane
   for (let section of sections) {
@@ -331,7 +331,7 @@ test('Validate the presentation of the checkboxes in the sections of the filter 
   }
 });
 
-// Validate that for any section with a dynamic list of checkboxes (do not consider "Contribution Opportunities") in the filter pane where there is a "View All" button,
+// Validate that for any section with a dynamic list of checkboxes (do not consider "Repository Signals") in the filter pane where there is a "View All" button,
 // - when I click on the "View All" button, the list of checkboxes is expanded
 // - the "View All" button is replaced by a "View Less" button
 // - all the checkboxes are presented (new count of checkboxes is greater than the initial count)
@@ -348,8 +348,8 @@ test('Validate the "View All" and "View Less" buttons in the filter pane in all 
     // Get the "View All" button
     let viewAllButton = await getButtonByName(section.section, 'View All');
 
-    // Skip the section if it is the "Contribution Opportunities" section or if there is no "View All" button
-    if (section.headerText === "Contribution Opportunities" || !viewAllButton) {
+    // Skip the section if it is the "Repository Signals" section or if there is no "View All" button
+    if (section.headerText === "Repository Signals" || !viewAllButton) {
       continue;
     }
 
@@ -399,10 +399,10 @@ test('Validate the "View All" and "View Less" buttons in the filter pane in all 
 
 // Validate the count of repositories based on the selection of 2 checkboxes in each section
 // - if the section is "Licenses" or "Owners", the count of repositories is the sum of the counts of the 2 checkboxes
-// - if the section is "Contribution Opportunities", "Topics", or "Languages", the count of repositories is the minimum of the counts of the 2 checkboxes
+// - if the section is "Repository Signals", "Topics", or "Languages", the count of repositories is the minimum of the counts of the 2 checkboxes
 test('Validate the count of repositories based on the selection of 2 checkboxes in each section', async ({ page }) => {
   const sectionBehaviors = [
-    { name: 'Contribution Opportunities', countBehavior: 'min' },
+    { name: 'Repository Signals', countBehavior: 'min' },
     { name: 'Topics', countBehavior: 'min' },
     { name: 'Languages', countBehavior: 'min' },
     { name: 'Licenses', countBehavior: 'sum' },
@@ -449,18 +449,20 @@ test('Validate the count of repositories based on the selection of 2 checkboxes 
 
 // #region Gallery functionality tests
 
-// Validate that the count of repositories in the header of the gallery is equal to the count of repositories found
+// Validate that the count of repositories in the header of the gallery is correct
+// With pagination (30 items/page), visible cards on page 1 = min(total, 30)
 test('Validate the count of repositories in the header of the gallery', async ({ page }) => {
   await page.goto('/');
 
-  // Get the count of repositories in the header of the gallery
+  // Get the total count from the gallery header
   const repositoriesCountInHeader = await getCountOfRepositories(page);
 
-  // Get the count of repositories found
+  // Get the count of repository cards visible on the current page
   const countOfRepositoriesPresentedInGallery = await (await waitForRepositoryCards(page)).count();
 
-  // Validate that the count of repositories in the header of the gallery is equal to the count of repositories found
-  expect(repositoriesCountInHeader).toBe(countOfRepositoriesPresentedInGallery);
+  // With pagination (30 items/page), visible cards ≤ 30; header reflects total filtered count
+  expect(countOfRepositoriesPresentedInGallery).toBeLessThanOrEqual(30);
+  expect(countOfRepositoriesPresentedInGallery).toBe(Math.min(repositoriesCountInHeader, 30));
 });
 
 // Validate that the default sorting option in the gallery is "Stars (Descending)"
@@ -587,7 +589,7 @@ test('Validate that when I change the sorting option in the gallery, the order o
 // - the number of stars
 // - the repository full name (owner and name)
 // - the description
-// - maximum 5 topics
+// - maximum 4 topics (+ optional "+N more" badge)
 // - an "Open in GitHub" button
 // - an "See more..." button
 test('Validate the information presented in the cards of the gallery', async ({ page }) => {
@@ -607,7 +609,7 @@ test('Validate the information presented in the cards of the gallery', async ({ 
     cardElements.map((card) => card.querySelectorAll('[data-testid="topic-badge"]').length)
   );
   for (const topicCount of topicCounts) {
-    expect(topicCount).toBeLessThanOrEqual(5);
+    expect(topicCount).toBeLessThanOrEqual(4);
   }
 
   const sampleIndexes = getRepresentativeIndexes(cardCount);
@@ -830,7 +832,7 @@ test('Validate that when I click on the "See more..." button in a random card of
  * @returns {Promise<number>} The count of repositories.
  */
 function getOrderByCombobox(page: Page): Locator {
-  return page.getByRole('combobox', { name: 'Order By' });
+  return page.getByRole('combobox', { name: 'Sort by' });
 }
 
 async function selectSortOption(page: Page, optionText: string) {

--- a/Website/tests/user_interface/tests/search-filter-pane-gallery-of-repositories.spec.ts
+++ b/Website/tests/user_interface/tests/search-filter-pane-gallery-of-repositories.spec.ts
@@ -126,8 +126,12 @@ test('Validate the filter pane default presentation', async ({ page }) => {
   await page.goto('/');
 
   // Array of the expected sections (the order is important)
+  // Categories, Focus Areas, and Audiences are conditionally rendered when the data contains values for them
   const expectedSections = [
     'Repository Signals',
+    'Categories',
+    'Focus Areas',
+    'Audiences',
     'Topics',
     'Languages',
     'Licenses',
@@ -177,7 +181,7 @@ test('Validate the filter pane default presentation', async ({ page }) => {
   const expandedSectionName = await expandedSections[0].innerText();
   expect(expandedSectionName).toBe(expectedSections[0]);
 
-  expect(nonExpandedSections.length).toBe(4);
+  expect(nonExpandedSections.length).toBe(expectedSections.length - 1);
   const nonExpandedSectionNames = await Promise.all(nonExpandedSections.map(async (section) => {
     return section.innerText();
   }));

--- a/Website/tests/user_interface/tests/search-filter-pane-gallery-of-repositories.spec.ts
+++ b/Website/tests/user_interface/tests/search-filter-pane-gallery-of-repositories.spec.ts
@@ -449,6 +449,36 @@ test('Validate the count of repositories based on the selection of 2 checkboxes 
   }
 });
 
+// Validate the "Clear all filters" button behavior
+// - button is hidden when no filters are active
+// - button appears when a filter is applied (including search text)
+// - clicking the button clears all active filters and restores the full count
+test('Validate the "Clear all filters" button behavior', async ({ page }) => {
+  await page.goto('/');
+
+  const clearButton = page.getByRole('button', { name: 'Clear all filters' });
+
+  // Button should not be visible initially (no active filters)
+  await expect(clearButton).not.toBeVisible();
+
+  // Apply a filter checkbox
+  const initialCount = await getCountOfRepositories(page);
+  const goodFirstIssueCheckbox = page.locator('#checkbox-r-good-first-issue');
+  await goodFirstIssueCheckbox.check();
+  await expect.poll(() => getCountOfRepositories(page)).toBeLessThan(initialCount);
+
+  // Button should now be visible
+  await expect(clearButton).toBeVisible();
+
+  // Click "Clear all filters" — all selections should reset and count should restore
+  await clearButton.click();
+  await expect(goodFirstIssueCheckbox).not.toBeChecked();
+  await expect.poll(() => getCountOfRepositories(page)).toBe(initialCount);
+
+  // Button should be hidden again
+  await expect(clearButton).not.toBeVisible();
+});
+
 // #endregion
 
 // #region Gallery functionality tests
@@ -467,6 +497,55 @@ test('Validate the count of repositories in the header of the gallery', async ({
   // With pagination (30 items/page), visible cards ≤ 30; header reflects total filtered count
   expect(countOfRepositoriesPresentedInGallery).toBeLessThanOrEqual(30);
   expect(countOfRepositoriesPresentedInGallery).toBe(Math.min(repositoriesCountInHeader, 30));
+});
+
+// Validate pagination navigation when more than 30 repositories are present
+test('Validate pagination navigation', async ({ page }) => {
+  await page.goto('/');
+
+  const totalCount = await getCountOfRepositories(page);
+
+  // Pagination only renders when total > 30
+  if (totalCount <= 30) {
+    // Not enough data to test pagination; skip gracefully
+    return;
+  }
+
+  // Page 1: Next button is enabled, Previous is disabled
+  const nextButton = page.getByRole('button', { name: 'Next' });
+  const prevButton = page.getByRole('button', { name: 'Previous' });
+  await expect(nextButton).toBeEnabled();
+  await expect(prevButton).toBeDisabled();
+
+  // Get the first card title on page 1
+  const page1Cards = await waitForRepositoryCards(page);
+  const firstCardPage1 = await page1Cards.first().textContent();
+
+  // Navigate to page 2
+  await nextButton.click();
+  await page.waitForFunction(() => {
+    const btn = document.querySelector('[aria-current="page"]');
+    return btn && btn.textContent?.trim() === '2';
+  });
+
+  // Page 2 should show different cards; Previous is now enabled
+  await expect(prevButton).toBeEnabled();
+  const page2Cards = await waitForRepositoryCards(page);
+  const firstCardPage2 = await page2Cards.first().textContent();
+  expect(firstCardPage2).not.toBe(firstCardPage1);
+
+  // Navigate back to page 1
+  await prevButton.click();
+  await page.waitForFunction(() => {
+    const btn = document.querySelector('[aria-current="page"]');
+    return btn && btn.textContent?.trim() === '1';
+  });
+
+  // Previous should be disabled again on page 1
+  await expect(prevButton).toBeDisabled();
+  const page1CardsAgain = await waitForRepositoryCards(page);
+  const firstCardPage1Again = await page1CardsAgain.first().textContent();
+  expect(firstCardPage1Again).toBe(firstCardPage1);
 });
 
 // Validate that the default sorting option in the gallery is "Stars (Descending)"


### PR DESCRIPTION
## UI/UX Improvements — Comprehensive Pass

This PR addresses 33 findings from a deep UX research session conducted with Playwright. Changes span 4 streams across the full website stack.

---

### Stream A — Homepage & Global Shell
- Fix heading hierarchy: hero title promoted to h1
- Add aria-label to search input
- Remove 500ms artificial loading delay; render gates on URL state initialization
- Hero title contrast: solid adaptive color via CSS class (no gradient overlay)
- Hero subtitle: adaptive color via CSS class (no hardcoded #242424)
- Dark mode hero: deep green-to-navy gradient (replaces identical-to-light-mode colors)
- Align mobile CSS breakpoint to 960px (matches JS isMobile threshold)
- Add overflow-x: hidden to prevent horizontal scroll at narrow viewports
- Override --ifm-navbar-mobile-breakpoint to 960px in custom.css
- Mobile Filters button: min-height 44px for touch target compliance
- Mobile filter dialog: return focus to Filters button on close
- Wire handleClearAllFilters and hasAnyActiveFilters to Gallery + FilterPane
- Update Layout meta description for SEO

### Stream B — Gallery Component
- Pagination: 30 items/page with Previous / numbered pages / Next controls
- Pagination resets to page 1 on any filter/search change (loop-safe via filterKey)
- Empty state: "No repositories found" with "Clear all filters" CTA
- Card hover: box-shadow + subtle translateY lift
- Mobile grid overflow fix at 960px breakpoint
- Card descriptions clamped to 3 lines
- Rename "Order By" to "Sort by"
- Show page info alongside result count in gallery header
- Card titles are clickable links (open GitHub in new tab)
- Cards have role=article + aria-label for screen readers
- Language badge and last-updated date shown on each card
- Topics capped at 4 with "+N more" overflow badge

### Stream C — Filter Pane
- Rename "Contribution Opportunities" to "Repository Signals"
- "Clear all filters" button shown when any filter is active
- Topics section: searchable + scrollable list when expanded
- Owners section: searchable + scrollable list when expanded
- Checkbox groups wrapped in ul/li for screen reader list semantics
- min-height 44px enforced on all checkbox list items

### Stream D — Docs, Config & Copy
- Fix typos in intro.md and self-onboarding.md
- Rename navbar title "PP OSS Hub" to "Power Platform OSS Hub"
- Add CTAs to find-solutions.md, contribute-to-projects.md, community index.md
- Install @docusaurus/plugin-client-redirects

---

### Validation
- npm run typecheck: no errors
- npm run test:unit: 85/85 tests pass
- npm run build: production build succeeds
- Playwright E2E tests updated for renamed UI elements, pagination, and 4-topic cap