### PR TITLE
fix: add missing TypeScript type annotations in galleryUtils

### DIFF
--- a/Website/src/utils/galleryUtils.tsx
+++ b/Website/src/utils/galleryUtils.tsx
@@ -150,7 +150,7 @@ export function filterItems(items: Repository[], filterParams: FilterParams): Re
  * @param {Array} selectedOptions - The selected options for sorting.
  * @returns {Array} - The sorted array of items.
  */
-export function sortItems(items, selectedOptions) {
+export function sortItems(items: Repository[], selectedOptions: string[]): Repository[] {
     const itemsCopy = [...items]; // Create a copy of the array
     const selectedOption = selectedOptions[0];
     const compareByFullName = (a: Repository, b: Repository) => a.fullName.localeCompare(b.fullName);
@@ -199,9 +199,17 @@ export function sortItems(items, selectedOptions) {
  * @param {string} dateString - The date string to check.
  * @returns {boolean} - True if the date is within the last 10 days, false otherwise.
  */
-export function isActive(dateString) {
+export function isActive(dateString: string | null | undefined): boolean {
+    if (!dateString) {
+        return false;
+    }
+
     const date = new Date(dateString);
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 10);
-    return date >= thirtyDaysAgo;
+    if (Number.isNaN(date.getTime())) {
+        return false;
+    }
+
+    const tenDaysAgo = new Date();
+    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+    return date >= tenDaysAgo;
 }


### PR DESCRIPTION
## Problem

The update-clean-website-dependencies workflow (run #26109581969) was failing at the Run unit tests step with three TypeScript TS7006 errors in Website/src/utils/galleryUtils.tsx:

- Parameter 'items' implicitly has an 'any' type (line 153)
- Parameter 'selectedOptions' implicitly has an 'any' type (line 153)
- Parameter 'dateString' implicitly has an 'any' type (line 202)

Two test suites (galleryUtils.test.tsx and filterUrlState.test.tsx) failed to compile, causing exit code 1.

## Fix

Added explicit TypeScript parameter and return types to the two affected functions.

### sortItems
- items: Repository[]
- selectedOptions: string[]
- return: Repository[]

### isActive
- dateString: string | null | undefined (covers null from tests and undefined from selectedItem?.updatedAt call site in Gallery/index.tsx)
- return: boolean
- Added explicit guards for null/undefined and invalid date strings for clearer intent and safer behavior

## Verification

All 5 test suites / 85 tests pass locally after the fix.