### PR TITLE
Remove curated metadata badges from gallery repository cards

### DIFF
--- a/Website/src/components/Gallery/index.tsx
+++ b/Website/src/components/Gallery/index.tsx
@@ -401,8 +401,6 @@ const Gallery = ({
                                     }
                                 </Text>
 
-                                {renderRelaunchBadges(item, 'card')}
-
                                 <div style={{ display: 'flex', flexWrap: 'wrap' }}>
                                     {item.topics.slice(0, 4).map((topic, index) => (
                                         renderTopicBadge(topic, `${topic}-${index}`, 'topic-badge')


### PR DESCRIPTION
## Motivation

Repository cards with rich curated metadata were overflowing their fixed max-height, causing the "Open in GitHub" and "See more..." footer buttons to be hidden and unreachable. Cards like `microsoft/PowerPlatformConnectors` or `microsoft/PowerApps-Samples` could render up to 8-11 curated badges (Category, Focus Areas, Audiences, Maintenance, Maturity) stacked above the GitHub topics section, pushing the footer out of view.

Additionally, these curated badges used the same visual style as GitHub topic badges, making it hard to distinguish curation metadata from community-sourced topics.

## What changed

Removed the `renderRelaunchBadges(item, 'card')` call from the gallery card template in `Website/src/components/Gallery/index.tsx`.

Gallery cards now show only:
- Repository name and description
- GitHub topics (up to 4 + overflow count)
- Language and last-updated date
- Footer action buttons (always visible)

All curated metadata (Category, Focus Areas, Audiences, Maintenance, Maturity) remains fully accessible via the "See more..." detail dialog, where there is plenty of space to display it properly.

## Tests

All 85 existing unit tests pass with no changes needed.