### PR TITLE
fix: resolve dependabot and code scanning security alerts

### DIFF
--- a/Scripts/Tests/Export-GitHubRepositoriesDetails.Tests.ps1
+++ b/Scripts/Tests/Export-GitHubRepositoriesDetails.Tests.ps1
@@ -1,15 +1,12 @@
 # To execute these tests run the following command from the root of the repository: Invoke-Pester -Script .\Scripts\Tests\Export-GitHubRepositoriesDetails.Tests.ps1
 
-# Set a script-scoped variable with the path of the executing script
-$script:executingTestPath = Split-Path -Parent $MyInvocation.MyCommand.Path
-
 BeforeAll {
     # Import Export-GitHubRepositoriesDetails function
-    Import-Module $script:executingTestPath/../Export-GitHubRepositoriesDetails.ps1 -Force
+    Import-Module $PSScriptRoot/../Export-GitHubRepositoriesDetails.ps1 -Force
 
     # Import required modules
-    Import-Module $script:executingTestPath/../../Scripts/Search-GitHubRepositories.ps1 -Force
-    Import-Module $script:executingTestPath/../../Scripts/Get-GitHubRepositoryDetails.ps1 -Force
+    Import-Module $PSScriptRoot/../../Scripts/Search-GitHubRepositories.ps1 -Force
+    Import-Module $PSScriptRoot/../../Scripts/Get-GitHubRepositoryDetails.ps1 -Force
 }
 
 Describe "Export-GitHubRepositoriesDetails Unit Tests" {
@@ -31,7 +28,7 @@ Describe "Export-GitHubRepositoriesDetails Unit Tests" {
         BeforeEach {
             Mock Test-Path { $true }
 
-            Import-Module $script:executingTestPath/../Search-GitHubRepositories.ps1 -Force
+            Import-Module $PSScriptRoot/../Search-GitHubRepositories.ps1 -Force
             Mock Search-GitHubRepositories {
                 @(
                     [PSCustomObject]@{
@@ -125,7 +122,7 @@ Describe "Export-GitHubRepositoriesDetails Unit Tests" {
                 }
             }
 
-            Import-Module $script:executingTestPath/../../Scripts/Get-GitHubRepositoryDetails.ps1 -Force
+            Import-Module $PSScriptRoot/../../Scripts/Get-GitHubRepositoryDetails.ps1 -Force
             Mock Get-GitHubRepositoryDetails {
                 [PSCustomObject]@{}
             }
@@ -245,8 +242,8 @@ Describe "Export-GitHubRepositoriesDetails Unit Tests" {
 
     Context "Committed data validation" {
         It "Should keep the committed repository details data aligned with the schema" {
-            $schemaFilePath = Join-Path -Path $script:executingTestPath -ChildPath "../../Configuration/Schemas/GitHubRepositoriesDetails.schema.json"
-            $dataFilePath = Join-Path -Path $script:executingTestPath -ChildPath "../../Data/GitHubRepositoriesDetails.json"
+            $schemaFilePath = Join-Path -Path $PSScriptRoot -ChildPath "../../Configuration/Schemas/GitHubRepositoriesDetails.schema.json"
+            $dataFilePath = Join-Path -Path $PSScriptRoot -ChildPath "../../Data/GitHubRepositoriesDetails.json"
 
             $dataAsJson = Get-Content -Path $dataFilePath -Raw
             $dataAsJson | Test-Json -SchemaFile $schemaFilePath | Should -Be $true

--- a/Scripts/Tests/Export-GitHubRepositoriesDetails.Tests.ps1
+++ b/Scripts/Tests/Export-GitHubRepositoriesDetails.Tests.ps1
@@ -1,15 +1,15 @@
 # To execute these tests run the following command from the root of the repository: Invoke-Pester -Script .\Scripts\Tests\Export-GitHubRepositoriesDetails.Tests.ps1
 
-# Set a global variable with the path of the executing script
-$global:executingTestPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+# Set a script-scoped variable with the path of the executing script
+$script:executingTestPath = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 BeforeAll {
     # Import Export-GitHubRepositoriesDetails function
-    Import-Module $global:executingTestPath/../Export-GitHubRepositoriesDetails.ps1 -Force
+    Import-Module $script:executingTestPath/../Export-GitHubRepositoriesDetails.ps1 -Force
 
     # Import required modules
-    Import-Module $global:executingTestPath/../../Scripts/Search-GitHubRepositories.ps1 -Force
-    Import-Module $global:executingTestPath/../../Scripts/Get-GitHubRepositoryDetails.ps1 -Force
+    Import-Module $script:executingTestPath/../../Scripts/Search-GitHubRepositories.ps1 -Force
+    Import-Module $script:executingTestPath/../../Scripts/Get-GitHubRepositoryDetails.ps1 -Force
 }
 
 Describe "Export-GitHubRepositoriesDetails Unit Tests" {
@@ -31,7 +31,7 @@ Describe "Export-GitHubRepositoriesDetails Unit Tests" {
         BeforeEach {
             Mock Test-Path { $true }
 
-            Import-Module $global:executingTestPath/../Search-GitHubRepositories.ps1 -Force
+            Import-Module $script:executingTestPath/../Search-GitHubRepositories.ps1 -Force
             Mock Search-GitHubRepositories {
                 @(
                     [PSCustomObject]@{
@@ -125,7 +125,7 @@ Describe "Export-GitHubRepositoriesDetails Unit Tests" {
                 }
             }
 
-            Import-Module $global:executingTestPath/../../Scripts/Get-GitHubRepositoryDetails.ps1 -Force
+            Import-Module $script:executingTestPath/../../Scripts/Get-GitHubRepositoryDetails.ps1 -Force
             Mock Get-GitHubRepositoryDetails {
                 [PSCustomObject]@{}
             }
@@ -245,8 +245,8 @@ Describe "Export-GitHubRepositoriesDetails Unit Tests" {
 
     Context "Committed data validation" {
         It "Should keep the committed repository details data aligned with the schema" {
-            $schemaFilePath = Join-Path -Path $global:executingTestPath -ChildPath "../../Configuration/Schemas/GitHubRepositoriesDetails.schema.json"
-            $dataFilePath = Join-Path -Path $global:executingTestPath -ChildPath "../../Data/GitHubRepositoriesDetails.json"
+            $schemaFilePath = Join-Path -Path $script:executingTestPath -ChildPath "../../Configuration/Schemas/GitHubRepositoriesDetails.schema.json"
+            $dataFilePath = Join-Path -Path $script:executingTestPath -ChildPath "../../Data/GitHubRepositoriesDetails.json"
 
             $dataAsJson = Get-Content -Path $dataFilePath -Raw
             $dataAsJson | Test-Json -SchemaFile $schemaFilePath | Should -Be $true

--- a/Website/package-lock.json
+++ b/Website/package-lock.json
@@ -7307,6 +7307,18 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -7340,6 +7352,163 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -8072,15 +8241,6 @@
       "integrity": "sha512-6I0fMH8Aoy2lOejL3s4LhyIYX34DPwY8bl5xlNjBvUEk8OHrcuzsFt+Ied4LvJihbtXPM+8zUqdydfIti86v9g==",
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/node-forge": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/prismjs": {
@@ -9077,6 +9237,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -9565,6 +9739,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -18661,15 +18844,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -19409,6 +19583,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/postcss": {
@@ -21076,6 +21267,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -21121,14 +21330,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -21470,6 +21671,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -22129,16 +22336,16 @@
       "license": "MIT"
     },
     "node_modules/selfsigned": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
       "license": "MIT",
       "dependencies": {
-        "@types/node-forge": "^1.3.0",
-        "node-forge": "^1"
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/semver": {
@@ -22226,11 +22433,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -23100,15 +23308,14 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
+      "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -23122,10 +23329,37 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
           "optional": true
         },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
         "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -23450,6 +23684,24 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
     "node_modules/type-detect": {
@@ -24287,14 +24539,14 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
-      "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.25",
         "@types/express-serve-static-core": "^4.17.21",
         "@types/serve-index": "^1.9.4",
         "@types/serve-static": "^1.15.5",
@@ -24304,9 +24556,9 @@
         "bonjour-service": "^1.2.1",
         "chokidar": "^3.6.0",
         "colorette": "^2.0.10",
-        "compression": "^1.7.4",
+        "compression": "^1.8.1",
         "connect-history-api-fallback": "^2.0.0",
-        "express": "^4.21.2",
+        "express": "^4.22.1",
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
@@ -24314,7 +24566,7 @@
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",
-        "selfsigned": "^2.4.1",
+        "selfsigned": "^5.5.0",
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
@@ -24374,9 +24626,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/Website/package.json
+++ b/Website/package.json
@@ -55,5 +55,8 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "overrides": {
+    "serialize-javascript": ">=7.0.5"
   }
 }


### PR DESCRIPTION
## Summary

Fixes all 4 Dependabot vulnerabilities and 2 code scanning alerts.

### Dependabot Vulnerabilities

| Alert | Package | Before | After |
|-------|---------|--------|-------|
| #104 (High) | serialize-javascript | 6.0.2 | 7.0.5 via overrides |
| #118 (Moderate) | serialize-javascript | 6.0.2 | 7.0.5 via overrides |
| #134 (Moderate) | webpack-dev-server | 5.2.2 | 5.2.4 |
| #135 (Moderate) | ws | 7.5.10 | 8.20.1 (nested in webpack-dev-server) |

The serialize-javascript upgrade (v6 to v7) is applied via npm overrides since it is a transitive dependency of copy-webpack-plugin and css-minimizer-webpack-plugin inside @docusaurus/bundler.

### Code Scanning Alerts (PSScriptAnalyzer PSAvoidGlobalVars)

| Alert | File | Fix |
|-------|------|-----|
| #108 (Warning) | Export-GitHubRepositoriesDetails.Tests.ps1:248 | global scope to script scope |
| #109 (Warning) | Export-GitHubRepositoriesDetails.Tests.ps1:249 | global scope to script scope |

All occurrences of global:executingTestPath replaced with script:executingTestPath. Functionality is unchanged since the variable is only used within the same script file.