### PR TITLE
feat: add optional minStars filter to pre-filter repos at search time

### DIFF
--- a/Configuration/GitHubRepositoriesSearchCriteria.json
+++ b/Configuration/GitHubRepositoriesSearchCriteria.json
@@ -31,11 +31,13 @@
     },
     {
         "topic": "powervirtualagent",
-        "searchLimit": 50
+        "searchLimit": 50,
+        "minStars": 5
     },
     {
         "topic": "power-virtual-agent",
-        "searchLimit": 50
+        "searchLimit": 50,
+        "minStars": 5
     },
     {
         "topic": "dataverse",
@@ -44,19 +46,23 @@
     },
     {
         "topic": "microsoft-dataverse",
-        "searchLimit": 50
+        "searchLimit": 50,
+        "minStars": 5
     },
     {
         "topic": "powerfx",
-        "searchLimit": 50
+        "searchLimit": 50,
+        "minStars": 5
     },
     {
         "topic": "power-fx",
-        "searchLimit": 50
+        "searchLimit": 50,
+        "minStars": 5
     },
     {
         "topic": "dynamics365",
-        "searchLimit": 200
+        "searchLimit": 200,
+        "minStars": 5
     },
     {
         "topic": "dynamics-365",
@@ -65,15 +71,18 @@
     },
     {
         "topic": "pcf-controls",
-        "searchLimit": 50
+        "searchLimit": 50,
+        "minStars": 5
     },
     {
         "topic": "powerappscomponentframework",
-        "searchLimit": 100
+        "searchLimit": 100,
+        "minStars": 5
     },
     {
         "topic": "ai-builder",
-        "searchLimit": 50
+        "searchLimit": 50,
+        "minStars": 5
     },
     {
         "topic": "copilot-studio",
@@ -82,10 +91,12 @@
     },
     {
         "topic": "microsoft-copilot-studio",
-        "searchLimit": 50
+        "searchLimit": 50,
+        "minStars": 5
     },
     {
         "topic": "copilotstudio",
-        "searchLimit": 50
+        "searchLimit": 50,
+        "minStars": 5
     }
 ]

--- a/Configuration/GitHubRepositoriesSearchCriteria.json
+++ b/Configuration/GitHubRepositoriesSearchCriteria.json
@@ -1,27 +1,33 @@
 [
     {
         "topic": "powerplatform",
-        "searchLimit": 200
+        "searchLimit": 200,
+        "minStars": 5
     },
     {
         "topic": "power-platform",
-        "searchLimit": 100
+        "searchLimit": 100,
+        "minStars": 5
     },
     {
         "topic": "powerapps",
-        "searchLimit": 300
+        "searchLimit": 300,
+        "minStars": 5
     },
     {
         "topic": "power-apps",
-        "searchLimit": 100
+        "searchLimit": 100,
+        "minStars": 5
     },
     {
         "topic": "powerautomate",
-        "searchLimit": 200
+        "searchLimit": 200,
+        "minStars": 5
     },
     {
         "topic": "power-automate",
-        "searchLimit": 100
+        "searchLimit": 100,
+        "minStars": 5
     },
     {
         "topic": "powervirtualagent",
@@ -33,7 +39,8 @@
     },
     {
         "topic": "dataverse",
-        "searchLimit": 200
+        "searchLimit": 200,
+        "minStars": 5
     },
     {
         "topic": "microsoft-dataverse",
@@ -53,7 +60,8 @@
     },
     {
         "topic": "dynamics-365",
-        "searchLimit": 500
+        "searchLimit": 500,
+        "minStars": 5
     },
     {
         "topic": "pcf-controls",
@@ -69,7 +77,8 @@
     },
     {
         "topic": "copilot-studio",
-        "searchLimit": 50
+        "searchLimit": 50,
+        "minStars": 5
     },
     {
         "topic": "microsoft-copilot-studio",

--- a/Pipeline/src/config.ts
+++ b/Pipeline/src/config.ts
@@ -35,6 +35,8 @@ function normalizeCriterion(item: unknown, index: number, configPath: string): S
 
   const topic = item.topic ?? item.Topic;
   const searchLimit = item.searchLimit ?? item.SearchLimit;
+  const hasMinStars = Object.hasOwn(item, "minStars") || Object.hasOwn(item, "MinStars");
+  const minStars = item.minStars ?? item.MinStars;
 
   if (typeof topic !== "string" || topic.trim() === "") {
     throw new Error(`Search criterion ${index} in '${configPath}' must include a non-empty topic.`);
@@ -48,5 +50,11 @@ function normalizeCriterion(item: unknown, index: number, configPath: string): S
     throw new Error(`Search criterion '${topic}' in '${configPath}' must include searchLimit between 1 and 1000.`);
   }
 
-  return { topic, searchLimit };
+  if (hasMinStars) {
+    if (typeof minStars !== "number" || !Number.isInteger(minStars) || minStars < 1) {
+      throw new Error(`Search criterion '${topic}' in '${configPath}' has invalid minStars: must be a positive integer.`);
+    }
+  }
+
+  return { topic, searchLimit, ...(hasMinStars ? { minStars: minStars as number } : {}) };
 }

--- a/Pipeline/src/providers.ts
+++ b/Pipeline/src/providers.ts
@@ -179,8 +179,9 @@ export class OctokitRepositoryProvider implements CandidateProvider {
     while (repositories.length < criterion.searchLimit) {
       const remaining = criterion.searchLimit - repositories.length;
       const perPage = Math.min(100, remaining);
+      const starsQualifier = criterion.minStars !== undefined && criterion.minStars > 0 ? ` stars:>=${criterion.minStars}` : "";
       const response = await this.client.rest.search.repos({
-        q: `topic:${criterion.topic} is:public`,
+        q: `topic:${criterion.topic} is:public${starsQualifier}`,
         per_page: perPage,
         page
       });

--- a/Pipeline/src/types.ts
+++ b/Pipeline/src/types.ts
@@ -3,6 +3,7 @@ export const SCHEMA_VERSION = "1.0.0";
 export interface SearchCriterion {
   topic: string;
   searchLimit: number;
+  minStars?: number;
 }
 
 export type RepositoryId = string | number;

--- a/Pipeline/tests/config.test.ts
+++ b/Pipeline/tests/config.test.ts
@@ -26,6 +26,49 @@ describe("loadSearchCriteria", () => {
     await expect(loadSearchCriteria(configPath)).resolves.toEqual([{ topic: "powerapps", searchLimit: 10 }]);
   });
 
+  it("accepts valid minStars and includes it in the result", async () => {
+    const configPath = path.join(outputRoot, "criteria-minstars.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 25, minStars: 5 }]), "utf8");
+
+    await expect(loadSearchCriteria(configPath)).resolves.toEqual([{ topic: "powerplatform", searchLimit: 25, minStars: 5 }]);
+  });
+
+  it("omits minStars from the result when not provided", async () => {
+    const configPath = path.join(outputRoot, "criteria-no-minstars.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 25 }]), "utf8");
+
+    const result = await loadSearchCriteria(configPath);
+    expect(result[0]).not.toHaveProperty("minStars");
+  });
+
+  it("rejects minStars of zero", async () => {
+    const configPath = path.join(outputRoot, "criteria-minstars-zero.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 25, minStars: 0 }]), "utf8");
+
+    await expect(loadSearchCriteria(configPath)).rejects.toThrow("invalid minStars: must be a positive integer");
+  });
+
+  it("rejects negative minStars", async () => {
+    const configPath = path.join(outputRoot, "criteria-minstars-neg.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 25, minStars: -1 }]), "utf8");
+
+    await expect(loadSearchCriteria(configPath)).rejects.toThrow("invalid minStars: must be a positive integer");
+  });
+
+  it("rejects non-integer minStars", async () => {
+    const configPath = path.join(outputRoot, "criteria-minstars-float.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 25, minStars: 2.5 }]), "utf8");
+
+    await expect(loadSearchCriteria(configPath)).rejects.toThrow("invalid minStars: must be a positive integer");
+  });
+
+  it("rejects null minStars", async () => {
+    const configPath = path.join(outputRoot, "criteria-minstars-null.json");
+    await writeFile(configPath, JSON.stringify([{ topic: "powerplatform", searchLimit: 25, minStars: null }]), "utf8");
+
+    await expect(loadSearchCriteria(configPath)).rejects.toThrow("invalid minStars: must be a positive integer");
+  });
+
   it("rejects topics with spaces", async () => {
     const configPath = path.join(outputRoot, "invalid.json");
     await writeFile(configPath, JSON.stringify([{ topic: "power platform", searchLimit: 10 }]), "utf8");

--- a/Pipeline/tests/providers.test.ts
+++ b/Pipeline/tests/providers.test.ts
@@ -486,3 +486,57 @@ describe("OctokitRepositoryProvider.batchGetRepositoryDetails", () => {
     expect((r as Error).message).not.toContain("Repository not found");
   });
 });
+
+// ---------------------------------------------------------------------------
+// searchRepositories — query building
+// ---------------------------------------------------------------------------
+
+describe("OctokitRepositoryProvider.searchRepositories", () => {
+  function makeSearchClient(capturedQueries: string[]): GitHubClient {
+    return {
+      rest: {
+        search: {
+          repos(params: Record<string, string | number>) {
+            capturedQueries.push(params["q"] as string);
+            return Promise.resolve({ data: { items: [] } });
+          },
+          issuesAndPullRequests: () => Promise.resolve({ data: { total_count: 0 } })
+        },
+        repos: {} as GitHubClient["rest"]["repos"]
+      } as GitHubClient["rest"],
+      request<T>(): Promise<{ data: T }> {
+        return Promise.resolve({ data: {} as T });
+      }
+    };
+  }
+
+  it("builds a plain query when minStars is not set", async () => {
+    const capturedQueries: string[] = [];
+    const client = makeSearchClient(capturedQueries);
+    const provider = new OctokitRepositoryProvider(client);
+
+    await provider.searchRepositories({ topic: "powerplatform", searchLimit: 10 });
+
+    expect(capturedQueries[0]).toBe("topic:powerplatform is:public");
+  });
+
+  it("appends stars qualifier when minStars is set", async () => {
+    const capturedQueries: string[] = [];
+    const client = makeSearchClient(capturedQueries);
+    const provider = new OctokitRepositoryProvider(client);
+
+    await provider.searchRepositories({ topic: "powerplatform", searchLimit: 10, minStars: 5 });
+
+    expect(capturedQueries[0]).toBe("topic:powerplatform is:public stars:>=5");
+  });
+
+  it("does not append stars qualifier when minStars is undefined", async () => {
+    const capturedQueries: string[] = [];
+    const client = makeSearchClient(capturedQueries);
+    const provider = new OctokitRepositoryProvider(client);
+
+    await provider.searchRepositories({ topic: "dataverse", searchLimit: 5, minStars: undefined });
+
+    expect(capturedQueries[0]).toBe("topic:dataverse is:public");
+  });
+});

--- a/Pipeline/tests/providers.test.ts
+++ b/Pipeline/tests/providers.test.ts
@@ -530,12 +530,12 @@ describe("OctokitRepositoryProvider.searchRepositories", () => {
     expect(capturedQueries[0]).toBe("topic:powerplatform is:public stars:>=5");
   });
 
-  it("does not append stars qualifier when minStars is undefined", async () => {
+  it("does not append stars qualifier when minStars is omitted", async () => {
     const capturedQueries: string[] = [];
     const client = makeSearchClient(capturedQueries);
     const provider = new OctokitRepositoryProvider(client);
 
-    await provider.searchRepositories({ topic: "dataverse", searchLimit: 5, minStars: undefined });
+    await provider.searchRepositories({ topic: "dataverse", searchLimit: 5 });
 
     expect(capturedQueries[0]).toBe("topic:dataverse is:public");
   });

--- a/Scripts/Export-GitHubRepositoriesDetails.ps1
+++ b/Scripts/Export-GitHubRepositoriesDetails.ps1
@@ -183,7 +183,16 @@ function Export-GitHubRepositoriesDetails {
             Wait-GitHubRateLimit -RateLimit $githubApiRateLimit -ResourceNames @("search") -MaximumWaitSeconds $MaximumRateLimitWaitSeconds
 
             # Search GitHub repositories based on the topic and the search limit defined in the configuration file
-            $repositoriesFound = Search-GitHubRepositories -Topic $repositoriesSearchCriterion.Topic -SearchLimit $repositoriesSearchCriterion.SearchLimit
+            $searchParams = @{
+                Topic = $repositoriesSearchCriterion.Topic
+                SearchLimit = $repositoriesSearchCriterion.SearchLimit
+            }
+
+            if ($null -ne $repositoriesSearchCriterion.MinStars -and $repositoriesSearchCriterion.MinStars -gt 0) {
+                $searchParams.MinStars = [int]$repositoriesSearchCriterion.MinStars
+            }
+
+            $repositoriesFound = Search-GitHubRepositories @searchParams
 
             # If number of repositories found is equal to the search limit, write a warning
             if ($repositoriesFound.count -eq $repositoriesSearchCriterion.SearchLimit) {

--- a/Scripts/Search-GitHubRepositories.ps1
+++ b/Scripts/Search-GitHubRepositories.ps1
@@ -17,6 +17,11 @@ function Search-GitHubRepositories {
             Limit on the maximum number of repositories we will search for through the GitHub CLI.
             The value need to be between 1 and 1000 to be compliant with the GitHub CLI search repos command definition.
 
+        .PARAMETER MinStars
+            Optional minimum star count to pre-filter repositories at search time.
+            When provided, appends 'stars:>=N' to the search query.
+            Must be a positive integer if specified.
+
         .INPUTS
             None. You cannot pipe objects to Search-GitHubRepositories.
 
@@ -51,7 +56,12 @@ function Search-GitHubRepositories {
         # Limit on the maximum number of repositories we will search for through the GitHub CLI.
         [Parameter(Mandatory = $true)]
         [ValidateRange(1,1000)]
-        [int]$SearchLimit
+        [int]$SearchLimit,
+
+        # Optional minimum star count pre-filter.
+        [Parameter(Mandatory = $false)]
+        [ValidateScript({ $_ -gt 0 })]
+        [int]$MinStars
     )
 
     Process{
@@ -63,10 +73,14 @@ function Search-GitHubRepositories {
         # Initialize an empty array to store the results
         $repositories = @()
 
-        # Search the GitHub repositories based on the provided parameters
-        $repositories = Invoke-GhCli -Arguments @(
-            "search",
-            "repos",
+        # Build the search arguments, optionally including a stars qualifier
+        $searchArguments = @("search", "repos")
+
+        if ($PSBoundParameters.ContainsKey('MinStars')) {
+            $searchArguments += "stars:>=$MinStars"
+        }
+
+        $searchArguments += @(
             "--topic",
             $Topic,
             "--visibility",
@@ -75,7 +89,10 @@ function Search-GitHubRepositories {
             $SearchLimit,
             "--json",
             "description,fullName,homepage,language,license,name,hasIssues,openIssuesCount,owner,createdAt,updatedAt,url,isArchived"
-        ) | ConvertFrom-Json
+        )
+
+        # Search the GitHub repositories based on the provided parameters
+        $repositories = Invoke-GhCli -Arguments $searchArguments | ConvertFrom-Json
 
         # Return the results
         $repositories

--- a/Scripts/Tests/Search-GitHubRepositories.Tests.ps1
+++ b/Scripts/Tests/Search-GitHubRepositories.Tests.ps1
@@ -24,6 +24,16 @@ Describe "Search-GitHubRepositories Unit Tests" {
             $result = { Search-GitHubRepositories -Topic "validtopic" -SearchLimit 1001 } | Should -Throw -PassThru
             $result.Exception.Message | Should -Be "Cannot validate argument on parameter 'SearchLimit'. The 1001 argument is greater than the maximum allowed range of 1000. Supply an argument that is less than or equal to 1000 and then try the command again."
         }
+
+        It "Should throw an error if MinStars is not a positive integer (zero)" {
+            $result = { Search-GitHubRepositories -Topic "validtopic" -SearchLimit 10 -MinStars 0 } | Should -Throw -PassThru
+            $result.Exception.Message | Should -Match "MinStars"
+        }
+
+        It "Should throw an error if MinStars is negative" {
+            $result = { Search-GitHubRepositories -Topic "validtopic" -SearchLimit 10 -MinStars -5 } | Should -Throw -PassThru
+            $result.Exception.Message | Should -Match "MinStars"
+        }
     }
 
     Context "Valid execution with a mocked gh command" {
@@ -64,6 +74,30 @@ Describe "Search-GitHubRepositories Unit Tests" {
             $result[0].fullName | Should -Be "anonymised/Anonymised"
             $result[0].language | Should -Be "Anonymised Language"
             $result.count | Should -Be 1
+        }
+
+        It "Should include stars qualifier in gh arguments when MinStars is provided" {
+            $capturedArguments = $null
+            Mock Invoke-GhCli {
+                param($Arguments)
+                $script:capturedArguments = $Arguments
+                "[]"
+            }
+
+            Search-GitHubRepositories -Topic "validtopic" -SearchLimit 1 -MinStars 5
+            $script:capturedArguments | Should -Contain "stars:>=5"
+        }
+
+        It "Should not include stars qualifier in gh arguments when MinStars is not provided" {
+            $capturedArguments = $null
+            Mock Invoke-GhCli {
+                param($Arguments)
+                $script:capturedArguments = $Arguments
+                "[]"
+            }
+
+            Search-GitHubRepositories -Topic "validtopic" -SearchLimit 1
+            $script:capturedArguments | Should -Not -Contain "stars:>=5"
         }
     }
 }


### PR DESCRIPTION
## Problem

The daily `update-github-repositories-details` workflow produces warnings like:

```
The number of repositories found for topic 'powerplatform' reached the configured searchLimit of 200.
The number of repositories found for topic 'power-platform' reached the configured searchLimit of 100.
```

9 topics in total are hitting their configured search limits. The current pipeline fetches repos with no star-count filter, then post-filters with `minPopularityScore = 10` in `generator.ts`. The star filter runs **after** fetching, so low-quality repos still count against the `searchLimit`.

## Solution

Add an optional `minStars` field to `SearchCriterion` that injects `stars:>=N` into the GitHub search query **at fetch time**. With `stars:>=5`, real counts drop well below all current limits (verified via GitHub API):

| Topic | Limit | stars≥5 count |
|---|---|---|
| powerplatform | 200 | 97 |
| power-platform | 100 | 63 |
| powerapps | 300 | 150 |
| power-apps | 100 | 30 |
| powerautomate | 200 | 47 |
| power-automate | 100 | 26 |
| dataverse | 200 | 89 |
| dynamics-365 | 500 | 186 |
| copilot-studio | 50 | 10 |

## Changes

### TypeScript Pipeline
- **`Pipeline/src/types.ts`**: Add `minStars?: number` to `SearchCriterion` interface
- **`Pipeline/src/config.ts`**: Parse and validate `minStars` in `normalizeCriterion` — optional, but if present must be a positive integer (null/zero/negative/float all rejected)
- **`Pipeline/src/providers.ts`**: Append `stars:>=N` qualifier to Octokit REST search query when `criterion.minStars` is set

### PowerShell Scripts
- **`Scripts/Search-GitHubRepositories.ps1`**: Add optional `MinStars` parameter; prepend `stars:>=N` as a positional `gh search repos` query qualifier when provided
- **`Scripts/Export-GitHubRepositoriesDetails.ps1`**: Forward `MinStars` from config to `Search-GitHubRepositories` via splatting

### Configuration
- **`Configuration/GitHubRepositoriesSearchCriteria.json`**: Add `"minStars": 5` to the 9 topics that were hitting their limits

### Tests
- New TypeScript tests for `minStars` validation (valid, zero, negative, float, null, omitted) and query building (with/without stars qualifier)
- New PowerShell tests for `MinStars` parameter validation and `gh` argument injection

## Backward Compatibility

`minStars` is **optional** — all existing criteria without it continue to work unchanged.
