### PR TITLE
fix(deps): force uuid >= 11.1.1 to fix CVE-2026-41907 (Dependabot #136)

### DIFF
--- a/Website/package-lock.json
+++ b/Website/package-lock.json
@@ -24270,12 +24270,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/Website/package.json
+++ b/Website/package.json
@@ -57,6 +57,7 @@
     "node": ">=18.0"
   },
   "overrides": {
-    "serialize-javascript": ">=7.0.5"
+    "serialize-javascript": ">=7.0.5",
+    "uuid": ">=11.1.1"
   }
 }


### PR DESCRIPTION
## Why

`uuid` 8.3.2 is a transitive dependency pulled in by `sockjs@0.3.24`, which uses a `^8.3.2` range constraint. This version contains a missing bounds-check vulnerability (CVE-2026-41907, CVSS 7.5 High) in UUID generation, flagged as Dependabot alert #136. Because of the major-version pin, normal `npm update` cannot resolve to the fixed version (>= 11.1.1).

## What changed

Added `"uuid": ">=11.1.1"` to the `overrides` block in `Website/package.json`, following the same pattern already used for `serialize-javascript`. This forces npm to resolve `uuid` to a safe version regardless of what `sockjs` declares in its own dependencies.

After running `npm install`, the lock file now resolves `uuid` to **14.0.0** (was 8.3.2), and `npm audit` reports **0 vulnerabilities**.

## Verification

- `npm audit` output: `found 0 vulnerabilities`
- `uuid` in `package-lock.json`: resolved to `14.0.0`
