### PR TITLE
chore(curation): exclude 3 false positive repos (May 2026 refresh)

### DIFF
--- a/Data/CuratedRepositories/inoerp/inoERP.json
+++ b/Data/CuratedRepositories/inoerp/inoERP.json
@@ -1,0 +1,7 @@
+{
+  "repositoryId": 16373462,
+  "fullName": "inoerp/inoERP",
+  "exclude": true,
+  "curationStatus": "reviewed",
+  "maintainerNotes": "False positive: Competing open-source ERP (Go + Flutter, modeled after Oracle R12 and SAP). Uses 'dynamics-365' topic for SEO comparison only. Zero Microsoft/Power Platform connection. Previously flagged HIGH confidence in May 2026 initial review but not actioned due to miscategorization with D365 F&O group."
+}

--- a/Data/CuratedRepositories/iqss/dataverse-pm.json
+++ b/Data/CuratedRepositories/iqss/dataverse-pm.json
@@ -1,0 +1,7 @@
+{
+  "repositoryId": 587403725,
+  "fullName": "IQSS/dataverse-pm",
+  "exclude": true,
+  "curationStatus": "reviewed",
+  "maintainerNotes": "False positive: Harvard IQSS Dataverse project management tracker. Org IQSS = Institute for Quantitative Social Science at Harvard. The 'dataverse' topic refers to their own academic data repository platform (dataverse.org), not Microsoft Dataverse. Same pattern as already-excluded IQSS/dataverse-client-r and IQSS/dataverse-uploader."
+}

--- a/Data/CuratedRepositories/steedos/awesome-low-code.json
+++ b/Data/CuratedRepositories/steedos/awesome-low-code.json
@@ -1,0 +1,7 @@
+{
+  "repositoryId": 262569785,
+  "fullName": "steedos/awesome-low-code",
+  "exclude": true,
+  "curationStatus": "reviewed",
+  "maintainerNotes": "False positive: Generic 'awesome list' of low-code platforms (Chinese-language) that lists Microsoft Power Apps as one item among ~20 platforms including Salesforce, OutSystems, Mendix, SAP, Appian, etc. Uses 'power-apps' topic for SEO. Not a Power Platform tool or community resource."
+}

--- a/Pipeline/tests/schema.test.ts
+++ b/Pipeline/tests/schema.test.ts
@@ -9,6 +9,7 @@ const repositoryRoot = path.resolve(packageRoot, "..");
 const schemaRoot = path.join(repositoryRoot, "Configuration", "Schemas");
 const taxonomyRoot = path.join(repositoryRoot, "Configuration", "Taxonomy");
 const overlayRoot = path.join(repositoryRoot, "Data", "CuratedRepositories");
+const generatedRoot = path.join(repositoryRoot, "Data", "GeneratedRepositories");
 
 type TaxonomyDefinitionName = "repositoryCategory" | "repositoryFocusArea" | "repositoryAudience";
 
@@ -210,9 +211,9 @@ describe("repository schemas", () => {
 
   it("validates curated overlay examples and sentinel safeguards", async () => {
     const validate = compileSchema("GitHubRepositoryOverlay.schema.json");
-    const overlayFiles = await listJsonFiles(overlayRoot);
-    const currentData = loadJson<RepositoryDetailsRecord[]>(path.join(repositoryRoot, "Data", "GitHubRepositoriesDetails.json"));
-    const currentByFullName = new Map(currentData.map((record) => [normalizeFullName(record.fullName ?? ""), record]));
+    const [overlayFiles, generatedFiles] = await Promise.all([listJsonFiles(overlayRoot), listJsonFiles(generatedRoot)]);
+    const generatedData = generatedFiles.map((filePath) => loadJson<RepositoryDetailsRecord>(filePath));
+    const generatedByRepositoryId = new Map(generatedData.map((record) => [String(record.repositoryId ?? ""), record]));
     const sentinelConfig = loadJson<{ repositories: SentinelRepository[] }>(path.join(repositoryRoot, "Configuration", "SentinelRepositories.json"));
     const sentinelFullNames = new Set(sentinelConfig.repositories.map((repository) => normalizeFullName(repository.fullName)));
     const repositoryIds = new Set<string>();
@@ -233,14 +234,15 @@ describe("repository schemas", () => {
       expect(fullNameParts).toHaveLength(2);
       const owner = fullNameParts[0] ?? "";
       const repositoryName = fullNameParts[1] ?? "";
-      expect(relativePath).toBe(path.join(owner.toLowerCase(), `${repositoryName.toLowerCase()}.json`));
+      const normalizedRelativePath = relativePath.split(path.sep).join("/").toLowerCase();
+      expect(normalizedRelativePath).toBe(`${owner.toLowerCase()}/${repositoryName.toLowerCase()}.json`);
 
       const normalizedFullName = normalizeFullName(overlay.fullName);
-      const currentRecord = currentByFullName.get(normalizedFullName);
-      expect(currentRecord).toBeDefined();
+      const generatedRecord = generatedByRepositoryId.get(String(overlay.repositoryId));
+      expect(generatedRecord).toBeDefined();
 
-      if (currentRecord?.repositoryId !== undefined) {
-        expect(String(currentRecord.repositoryId)).toBe(String(overlay.repositoryId));
+      if (generatedRecord?.fullName !== undefined) {
+        expect(normalizeFullName(generatedRecord.fullName)).toBe(normalizedFullName);
       }
 
       expect(repositoryIds.has(String(overlay.repositoryId))).toBe(false);


### PR DESCRIPTION
## Why

A systematic re-scan of the active repository list (215 repos, May 2026) identified three repos that match tracked Power Platform topics solely through SEO tagging or org-level patterns, with no actual Microsoft/Power Platform content. One was missed in the previous review; one was previously identified but not actioned due to miscategorization; one is newly surfaced.

## What changed

Three curated overlay files added under `Data/CuratedRepositories/`:

| Repo | Topic trigger | Reason for exclusion |
|---|---|---|
| `IQSS/dataverse-pm` | `dataverse` | Harvard IQSS Dataverse project management tracker. Same org as already-excluded `dataverse-client-r` and `dataverse-uploader` (PR #77). `dataverse` refers to the academic data platform at [dataverse.org](https://dataverse.org), not Microsoft Dataverse. |
| `steedos/awesome-low-code` | `power-apps` | Chinese-language awesome list of ~20 low-code platforms (Salesforce, OutSystems, Mendix, SAP, Appian, ...). Power Apps is listed as one item; `power-apps` topic is applied for SEO. No Power Platform-specific content. |
| `inoerp/inoERP` | `dynamics-365` | Competing open-source ERP (Go + Flutter) modeled after Oracle R12 and SAP. Uses `dynamics-365` topic for discoverability/comparison only. Previously flagged HIGH confidence in the May 2026 initial review but not actioned due to miscategorization with in-scope D365 F&O repos. |

## Patterns to watch going forward

- **`IQSS/*`** -- three repos now excluded from this org; worth an org-level block if the pipeline supports it.
- **`power-apps` topic** -- increasingly used by multi-platform comparison lists that merely mention Power Apps.
- **`dynamics-365` topic** -- competing ERPs (Oracle/SAP-style) add it for SEO; verify any such repo has no real Microsoft integration.