### PR TITLE
fix: add workflow_dispatch to Deploy to GitHub Pages condition

### DIFF
--- a/.github/workflows/build-push-website-to-gh-pages.yml
+++ b/.github/workflows/build-push-website-to-gh-pages.yml
@@ -132,7 +132,8 @@ jobs:
       - name: Deploy to GitHub Pages
         if: >
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main')
+          (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main') ||
+          github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The **Deploy to GitHub Pages** step in `build-push-website-to-gh-pages.yml` was silently skipped whenever the workflow was triggered via `workflow_dispatch`.

The `1-update-github-repositories-details` workflow pushes data updates using `GITHUB_TOKEN`, which intentionally does not trigger other workflows. It therefore dispatches the build workflow explicitly:

```
gh workflow run build-push-website-to-gh-pages.yml --ref main
```

This fires a `workflow_dispatch` event. However, the deploy step only allowed deployment for `push` and `workflow_run` events:

```yaml
- name: Deploy to GitHub Pages
  if: >
    (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
    (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main')
```

Because `workflow_dispatch` was not listed, every automatic data-update triggered this way would build successfully but never deploy — meaning exclusions and repository-details updates never reflected on the live site.

## Fix

Add `github.event_name == 'workflow_dispatch'` as a third allowed condition:

```yaml
- name: Deploy to GitHub Pages
  if: >
    (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
    (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main') ||
    github.event_name == 'workflow_dispatch'
```

No other logic is changed. The `workflow_dispatch` trigger was already listed in the `on:` block, so this simply aligns the deploy gate with all intended trigger paths.
